### PR TITLE
AimMods.cpp doesn't exist

### DIFF
--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -462,7 +462,6 @@ add_library(core
   PowerPC/Interpreter/Interpreter_Paired.cpp
   PowerPC/Interpreter/Interpreter_SystemRegisters.cpp
   PowerPC/Interpreter/Interpreter_Tables.cpp
-	PrimeHack/AimMods.cpp
   PrimeHack/HackConfig.cpp
   PrimeHack/HackManager.cpp
 )


### PR DESCRIPTION
Still doesn't build after that, though. Maybe you forgot to add the file?