### PR TITLE
Fix Windows compilation using CMake

### DIFF
--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -1,9 +1,15 @@
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    set(input DInputMouseAbsolute.cpp DInputMouseAbsolute.h)
+else()
+    # TODO add Mac support
+    set(input XInput2Mouse.cpp XInput2Mouse.h)
+endif()
+
 add_library(inputcommon
   InputConfig.cpp
   InputConfig.h
   GenericMouse.cpp
-	XInput2Mouse.cpp
-	XInput2Mouse.h
+  ${input}
   InputProfile.cpp
   InputProfile.h
   ControllerEmu/ControllerEmu.cpp

--- a/Source/Core/VideoCommon/CommandProcessor.cpp
+++ b/Source/Core/VideoCommon/CommandProcessor.cpp
@@ -196,7 +196,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
   }
 
   mmio->Register(base | FIFO_BP_LO, MMIO::DirectRead<u16>(MMIO::Utils::LowPart(&fifo.CPBreakpoint)),
-                 MMIO::ComplexWrite<u16>([](u32, u16 val) {
+                 MMIO::ComplexWrite<u16>([WMASK_LO_ALIGN_32BIT](u32, u16 val) {
                    WriteLow(fifo.CPBreakpoint, val & WMASK_LO_ALIGN_32BIT);
                  }));
   mmio->Register(base | FIFO_BP_HI,


### PR DESCRIPTION
- Edit `Source/Core/InputCommon/CMakeLists.txt` to include the proper mouse-input files when building using CMake.
- CommandProcessor.cpp had a compilation failure locally. After I captured a variable to fix the build, Qt Creator IDE complained the capture was unnecessary. I don't know what's going on.

Should I split this into two pull requests?

The CMakeLists indentation is already inconsistent. I made it more inconsistent. Yay.

I didn't run clang-format before committing my diff. Do you care about the minor changes to .cpp formatting?