### PR TITLE
Beam & Visor menus working on latest beta.

### DIFF
--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -197,6 +197,17 @@ void Pause()
   WiimoteReal::Pause();
 }
 
+bool CheckVisorMenu() {
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+
+  return wiimote->CheckVisorMenuCtrl();
+}
+
+bool CheckBeamMenu() {
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+
+  return wiimote->CheckBeamMenuCtrl();
+}
 
 bool CheckVisor(int visorcount)
 {

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -99,6 +99,8 @@ ControllerEmu::ControlGroup* GetDrawsomeTabletGroup(int number,
                                                     WiimoteEmu::DrawsomeTabletGroup group);
 ControllerEmu::ControlGroup* GetTaTaConGroup(int number, WiimoteEmu::TaTaConGroup group);
 
+bool CheckVisorMenu();
+bool CheckBeamMenu();
 
 bool CheckVisor(int visor_count);
 bool CheckBeam(int beam_count);

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -665,6 +665,18 @@ bool Wiimote::IsButtonPressed()
   return buttons != 0;
 }
 
+bool Wiimote::CheckVisorMenuCtrl()
+{
+  // Index for '-' button: 4
+  return m_buttons->controls[4].get()->control_ref->State() > 0.5;
+}
+
+bool Wiimote::CheckBeamMenuCtrl()
+{
+  // Index for '+' button: 5
+  return m_buttons->controls[5].get()->control_ref->State() > 0.5;
+}
+
 bool Wiimote::CheckVisorCtrl(int visorcount)
 {
   return m_primehack_visors->controls[visorcount].get()->control_ref->State() > 0.5;

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -139,6 +139,9 @@ public:
   void InterruptDataOutput(const u8* data, u32 size) override;
   bool IsButtonPressed() override;
 
+  bool CheckVisorMenuCtrl();
+  bool CheckBeamMenuCtrl();
+
   bool CheckVisorCtrl(int visor_count);
   bool CheckBeamCtrl(int beam_count);
   bool CheckBeamScrollCtrl(bool direction);

--- a/Source/Core/Core/PrimeHack/HackConfig.cpp
+++ b/Source/Core/Core/PrimeHack/HackConfig.cpp
@@ -67,6 +67,14 @@ void InitializeHack(std::string const& mkb_device_name, std::string const& mkb_d
   hack_mgr.enable_mod("skip_cutscene");
 }
 
+bool CheckBeamMenuCtl() {
+  return Wiimote::CheckBeamMenu();
+}
+
+bool CheckVisorMenuCtl() {
+  return Wiimote::CheckVisorMenu();
+}
+
 bool CheckBeamCtl(int beam_num) {
   return Wiimote::CheckBeam(beam_num);
 }

--- a/Source/Core/Core/PrimeHack/HackConfig.h
+++ b/Source/Core/Core/PrimeHack/HackConfig.h
@@ -10,6 +10,9 @@
 namespace prime {
 void InitializeHack(std::string const& mkb_device_name, std::string const& mkb_device_source);
 
+bool CheckBeamMenuCtl();
+bool CheckVisorMenuCtl();
+
 bool CheckBeamCtl(int beam_num);
 bool CheckVisorCtl(int visor_num);
 bool CheckBeamScrollCtl(bool direction);

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.h
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.h
@@ -19,6 +19,12 @@ namespace prime {
     void init_mod(Game game, Region region) override;
 
   private:
+    enum class Beam_Visor_Menu_State {
+      SET_VISOR = -1,
+      SET_BEAM = 1,
+      IDLE = 0,
+    };
+
     // ------------------------------
     // -----Active Mod Functions-----
     // ------------------------------
@@ -27,6 +33,10 @@ namespace prime {
     void handle_beam_visor_switch(std::array<int, 4> const &beams,
       std::array<std::tuple<int, int>, 4> const &visors);
     void mp3_handle_cursor(bool lock);
+
+    bool beam_visor_menu_handler(u32 cursor_base, u32 yaw_vel_address, Game game);
+    bool mp3_visor_menu_handler(u32 cursor_base, u32 yaw_vel_address);
+    void determine_selected_beam_visor(Game game, Beam_Visor_Menu_State beam_visor);
 
     void run_mod_menu(Region region);
     void run_mod_mp1();
@@ -60,6 +70,10 @@ namespace prime {
     u32 powerups_offset;
     u32 new_beam_address;
     u32 beamchange_flag_address;
+
+    bool use_original_beam_menu_code;
+
+    Beam_Visor_Menu_State menu_cursor_state = Beam_Visor_Menu_State::IDLE;
     // Required due to MP3
     bool has_beams;
     bool fighting_ridley;
@@ -76,6 +90,10 @@ namespace prime {
         u32 lockon_address;
         u32 tweak_player_address;
         u32 cplayer_address;
+
+        u32 cursor_ptr_address;
+        u32 cursor_offset;
+        u32 state_manager_address;
       } mp1_static;
 
       struct {
@@ -91,6 +109,10 @@ namespace prime {
         u32 cplayer_ptr_address;
         u32 load_state_address;
         u32 lockon_address;
+
+        u32 cursor_ptr_address;
+        u32 cursor_offset;
+        u32 state_manager_address;
       } mp2_static;
 
       struct {

--- a/Source/Core/Core/PrimeHack/PrimeUtils.h
+++ b/Source/Core/Core/PrimeHack/PrimeUtils.h
@@ -42,6 +42,11 @@ void set_beam_owned(int index, bool owned);
 void set_visor_owned(int index, bool owned);
 void set_cursor_pos(float x, float y);
 
+float get_cursor_x();
+float get_cursor_y();
+void request_beam_change(int beam);
+void request_visor_change(int beam);
+
 void DevInfo(const char* name, const char* format, ...);
 void DevInfoMatrix(const char* name, const Transform& t);
 std::tuple<u32, u32, u32> GetCheatsTime();

--- a/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
+++ b/Source/Core/InputCommon/ControlReference/ExpressionParser.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <functional>
 
 #include "Common/Common.h"
 #include "Common/StringUtil.h"


### PR DESCRIPTION
Code formatted appropriately.

Experimental: bool toggle to use MPT's original beam/visor selection code, instead of the PrimeHack reimplmentation (Prime 1 & 2 only).