### PR TITLE
Fix view snap back after lock-on in mp1

### DIFF
--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.h
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.h
@@ -23,6 +23,7 @@ namespace prime {
     // -----Active Mod Functions-----
     // ------------------------------
     void calculate_pitch_delta();
+    void calculate_pitch_locked();
     float calculate_yaw_vel();
     void handle_beam_visor_switch(std::array<int, 4> const &beams,
                                   std::array<std::tuple<int, int>, 4> const& visors);
@@ -77,6 +78,8 @@ namespace prime {
         u32 lockon_address;
         u32 tweak_player_address;
         u32 cplayer_address;
+        u32 object_list_ptr_address;
+        u32 camera_uid_address;
       } mp1_static;
 
       struct {


### PR DESCRIPTION
This continuously writes out the viewangle pitch to match the lock-on pitch even while locked on. 

This ensures that the instant the lock-on is released the view will not be a snap back to the old position, but instead it will remain exactly where the lock-on was last aiming.

I've only implemented it for mp1 wii edition, I can do it for the other versions but that will take a little longer. 

I also don't have the gamecube versions of mp1 or mp2, but I suppose I could acquire them.

Note this tends to the issue here: https://github.com/shiiion/dolphin/issues/28

Also excuse me, I'm a git noob, the commit author is my desktop user even though I set my global git config email and username -- I'm not sure what the hell is going on there but if anybody could tell me how to fix that I would do so.