### PR TITLE
Implemented MP3 Standalone NTSC-J support

### DIFF
--- a/Source/Core/Core/PrimeHack/HackManager.cpp
+++ b/Source/Core/Core/PrimeHack/HackManager.cpp
@@ -104,6 +104,10 @@ void HackManager::run_active_mods() {
       active_game = Game::PRIME_3_STANDALONE;
       active_region = Region::NTSC_U;
     }
+    else if (region_code == FOURCC('R', 'M', '3', 'J')) {
+      active_game = Game::PRIME_3_STANDALONE;
+      active_region = Region::NTSC_J;
+    }
     else if (region_code == FOURCC('R', 'M', '3', 'P')) {
       active_game = Game::PRIME_3_STANDALONE;
       active_region = Region::PAL;

--- a/Source/Core/Core/PrimeHack/Mods/AutoEFB.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/AutoEFB.cpp
@@ -28,6 +28,11 @@ void AutoEFB::run_mod(Game game, Region region) {
       const u32 visor_base = read32(read32(read32(cplayer_ptr_address) + 0x2184) + 0x35a0);
       should_use = read32(visor_base + 0x34) != 1u;
     }
+    else if (region == Region::NTSC_J)
+    {
+      const u32 visor_base = read32(read32(read32(read32(cplayer_ptr_address) + 4) + 0x2184) + 0x35a8);
+      should_use = read32(visor_base + 0x34) != 1u;
+    }
     else if (region == Region::PAL)
     {
       const u32 visor_base = read32(read32(read32(read32(cplayer_ptr_address) + 4) + 0x2184) + 0x35a0);
@@ -76,6 +81,10 @@ void AutoEFB::init_mod(Game game, Region region) {
     if (region == Region::NTSC_U)
     {
       cplayer_ptr_address = 0x805c4f98;
+    }
+    else if (region == Region::NTSC_J)
+    {
+      cplayer_ptr_address = 0x805caa5c;
     }
     else if (region == Region::PAL)
     {

--- a/Source/Core/Core/PrimeHack/Mods/ContextSensitiveControls.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/ContextSensitiveControls.cpp
@@ -115,6 +115,14 @@ void ContextSensitiveControls::init_mod(Game game, Region region) {
       cplayer_ptr_address = 0x805c4f98;
       motion_vtf_address = 0x802e2508;
     }
+    else if (region == Region::NTSC_J) {
+      code_changes.emplace_back(0x801fdb5c, 0x3D808000);
+      code_changes.emplace_back(0x801fdb64, 0x618C4170);
+      code_changes.emplace_back(0x801fdb6c, 0xC02C0000);
+
+      cplayer_ptr_address = 0x805caa5c;
+      motion_vtf_address = 0x802e5ed8;
+    }
     else if (region == Region::PAL) {
       code_changes.emplace_back(0x801fc5a8, 0x3D808000);
       code_changes.emplace_back(0x801fc5b0, 0x618C4170);

--- a/Source/Core/Core/PrimeHack/Mods/DisableBloom.h
+++ b/Source/Core/Core/PrimeHack/Mods/DisableBloom.h
@@ -45,6 +45,10 @@ public:
       {
         code_changes.emplace_back(0x80486880, 0x4e800020);
       }
+      else if (region == Region::NTSC_J)
+      {
+        code_changes.emplace_back(0x8048b34c, 0x4e800020);
+      }
       else if (region == Region::PAL)
       {
         code_changes.emplace_back(0x804885a4, 0x4e800020);

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.h
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.h
@@ -61,6 +61,7 @@ private:
   // All 3 of these games have this in common (MP3 just ignores beams)
   u32 active_visor_offset;
   u32 powerups_ptr_address;
+  u32 powerups_ptr_offset;
   u32 powerups_size;
   u32 powerups_offset;
   u32 new_beam_address;
@@ -84,6 +85,7 @@ private:
       u32 object_list_ptr_address;
       u32 camera_uid_address;
       u32 beamvisor_menu_address;
+      u32 beamvisor_menu_offset;
       u32 cursor_base_address;
       u32 cursor_offset;
     } mp1_static;
@@ -102,13 +104,15 @@ private:
       u32 load_state_address;
       u32 lockon_address;
       u32 beamvisor_menu_address;
+      u32 beamvisor_menu_offset;
       u32 cursor_base_address;
       u32 cursor_offset;
+      u32 tweak_player_offset;
     } mp2_static;
 
     struct {
       u32 state_mgr_address;
-      u32 player_tweak_offset;
+      u32 tweak_player_offset;
     } mp2_gc_static;
 
     struct {
@@ -120,6 +124,8 @@ private:
       u32 lockon_address;
       u32 gun_lag_toc_offset;
       u32 beamvisor_menu_address;
+      u32 beamvisor_menu_offset;
+      u32 cplayer_pitch_offset;
     } mp3_static;
   };
 

--- a/Source/Core/Core/PrimeHack/Mods/Invulnerability.h
+++ b/Source/Core/Core/PrimeHack/Mods/Invulnerability.h
@@ -8,6 +8,8 @@ class Invulnerability : public PrimeMod {
 public:
   void run_mod(Game game, Region region) override {}
   void init_mod(Game game, Region region) override {
+    u8 version = read8(0x80000007);
+
     switch (game) {
     case Game::PRIME_1:
       if (region == Region::NTSC_U) {
@@ -25,8 +27,10 @@ public:
       break;
     case Game::PRIME_1_GCN:
       if (region == Region::NTSC_U) {
-        code_changes.emplace_back(0x80011d3c, 0x3863d780);
-        code_changes.emplace_back(0x80011d48, 0x3863d780);
+        if (version == 0) {
+          code_changes.emplace_back(0x80011d3c, 0x3863d780);
+          code_changes.emplace_back(0x80011d48, 0x3863d780);
+        }
       }
       else if (region == Region::PAL) {
         code_changes.emplace_back(0x80012670, 0x3863f820);

--- a/Source/Core/Core/PrimeHack/Mods/Noclip.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/Noclip.cpp
@@ -32,6 +32,10 @@ void Noclip::run_mod(Game game, Region region)
 
 bool Noclip::has_control_mp1_gc()
 {
+  u8 version = read8(0x80000007);
+  if (version != 0) {
+    return false;
+  }
   u32 world_address = read32(mp1_gc_static.state_mgr_address + 0x850);
   if (!mem_check(world_address))
   {
@@ -160,6 +164,12 @@ void Noclip::run_mod_mp1(bool has_control)
 
 void Noclip::run_mod_mp1_gc(bool has_control)
 {
+  u8 version = read8(0x80000007);
+
+  if (version != 0) {
+    return;
+  }
+
   if (!has_control)
   {
     player_tf.read_from(mp1_gc_static.cplayer_address + 0x34);
@@ -314,6 +324,8 @@ void Noclip::run_mod_mp3(bool has_control)
 
 void Noclip::init_mod(Game game, Region region)
 {
+  u8 version = read8(0x80000007);
+
   initialized = true;
   switch (game)
   {
@@ -373,23 +385,25 @@ void Noclip::init_mod(Game game, Region region)
   case Game::PRIME_1_GCN:
     if (region == Region::NTSC_U)
     {
-      noclip_code_mp1_gc(0x8046b97c, 0x805afd00, 0x80052e90);
-      // For whatever reason CPlayer::Teleport calls SetTransform then SetTranslation
-      // which the above code changes will mess up, so just force the position to be
-      // used in SetTransform and remove the call to SetTranslation, now Teleport works
-      // when SetTranslation is ignoring the player
-      // This is handled above in mp1 trilogy as well
-      code_changes.emplace_back(0x80285128, 0x60000000);
-      code_changes.emplace_back(0x80285138, 0x60000000);
-      code_changes.emplace_back(0x80285140, 0x60000000);
-      code_changes.emplace_back(0x80285168, 0xd0010078);
-      code_changes.emplace_back(0x8028516c, 0xd0210088);
-      code_changes.emplace_back(0x80285170, 0xd0410098);
-      code_changes.emplace_back(0x80285174, 0x4808d9cd);
+      if (version == 0) {
+        noclip_code_mp1_gc(0x8046b97c, 0x805afd00, 0x80052e90);
+        // For whatever reason CPlayer::Teleport calls SetTransform then SetTranslation
+        // which the above code changes will mess up, so just force the position to be
+        // used in SetTransform and remove the call to SetTranslation, now Teleport works
+        // when SetTranslation is ignoring the player
+        // This is handled above in mp1 trilogy as well
+        code_changes.emplace_back(0x80285128, 0x60000000);
+        code_changes.emplace_back(0x80285138, 0x60000000);
+        code_changes.emplace_back(0x80285140, 0x60000000);
+        code_changes.emplace_back(0x80285168, 0xd0010078);
+        code_changes.emplace_back(0x8028516c, 0xd0210088);
+        code_changes.emplace_back(0x80285170, 0xd0410098);
+        code_changes.emplace_back(0x80285174, 0x4808d9cd);
 
-      mp1_gc_static.cplayer_address = 0x8046b97c;
-      mp1_gc_static.state_mgr_address = 0x8045a1a8;
-      mp1_gc_static.camera_uid_address = 0x8045c5b4;
+        mp1_gc_static.cplayer_address = 0x8046b97c;
+        mp1_gc_static.state_mgr_address = 0x8045a1a8;
+        mp1_gc_static.camera_uid_address = 0x8045c5b4;
+      }
     }
     else if (region == Region::PAL)
     {
@@ -545,6 +559,20 @@ void Noclip::init_mod(Game game, Region region)
 
       mp3_static.state_mgr_ptr_address = 0x805c4f6c;
       mp3_static.cam_uid_ptr_address = 0x805c4fa4;
+    }
+    else if (region == Region::NTSC_J)
+    {
+      noclip_code_mp3(0x805caa30, 0x80004380, 0x8000bee8);
+      code_changes.emplace_back(0x8017dd54, 0x60000000);
+      code_changes.emplace_back(0x8017dd5c, 0x60000000);
+      code_changes.emplace_back(0x8017dd64, 0x60000000);
+      code_changes.emplace_back(0x8017dd6c, 0xd0410084);
+      code_changes.emplace_back(0x8017dd70, 0xd0210094);
+      code_changes.emplace_back(0x8017dd74, 0xd00100a4);
+      code_changes.emplace_back(0x8017dd78, 0x4be938a1);
+
+      mp3_static.state_mgr_ptr_address = 0x805caa30;
+      mp3_static.cam_uid_ptr_address = 0x805caa68;
     }
     else if (region == Region::PAL)
     {
@@ -702,6 +730,7 @@ void Noclip::on_state_change(ModState old_state)
         }
       }
       break;
+      case Region::NTSC_J:
       case Region::PAL:
       {
         const u32 cplayer_address = read32(read32(mp3_static.state_mgr_ptr_address + 0x28) + 0x2184);
@@ -769,6 +798,7 @@ void Noclip::on_state_change(ModState old_state)
         }
       }
       break;
+      case Region::NTSC_J:
       case Region::PAL:
       {
         const u32 cplayer_address = read32(read32(mp3_static.state_mgr_ptr_address + 0x28) + 0x2184);

--- a/Source/Core/Core/PrimeHack/Mods/SkipCutscene.h
+++ b/Source/Core/Core/PrimeHack/Mods/SkipCutscene.h
@@ -7,6 +7,8 @@ class SkipCutscene : public PrimeMod {
 public:
   void run_mod(Game game, Region region) override { }
   void init_mod(Game game, Region region) override {
+    u8 version = read8(0x80000007);
+
     switch (game)
     {
     case Game::PRIME_1:
@@ -26,7 +28,12 @@ public:
     case Game::PRIME_1_GCN:
       if (region == Region::NTSC_U)
       {
-        add_return_one(0x801d5528);
+        if (version == 0) {
+          add_return_one(0x801d5528);
+        }
+        else if (version == 2) {
+          add_return_one(0x8015204c);
+        }
       }
       else if (region == Region::PAL)
       {
@@ -71,6 +78,10 @@ public:
       if (region == Region::NTSC_U)
       {
         add_return_one(0x800bb930);
+      }
+      else if (region == Region::NTSC_J)
+      {
+        add_return_one(0x800bc10c);
       }
       else if (region == Region::PAL)
       {

--- a/Source/Core/Core/PrimeHack/Mods/SpringballButton.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/SpringballButton.cpp
@@ -29,6 +29,7 @@ void SpringballButton::run_mod(Game game, Region region) {
       springball_check(actual_cplayer_address + 0x358, actual_cplayer_address + 0x29c);
       DevInfo("CPlayer", "%08X", cplayer_address);
       break;
+    case Region::NTSC_J:
     case Region::PAL:
       actual_cplayer_address = read32(read32(read32(cplayer_address) + 0x04) + 0x2184);
       springball_check(actual_cplayer_address + 0x358, actual_cplayer_address + 0x29c);
@@ -85,6 +86,10 @@ void SpringballButton::init_mod(Game game, Region region) {
     if (region == Region::NTSC_U) {
       cplayer_address = 0x805c4f98;
       springball_code(0x8010c984);
+    }
+    else if (region == Region::NTSC_J) {
+      cplayer_address = 0x805caa5c;
+      springball_code(0x8010d49c);
     }
     else if (region == Region::PAL) {
       cplayer_address = 0x805c759c;

--- a/Source/Core/Core/PrimeHack/Mods/ViewModifier.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/ViewModifier.cpp
@@ -89,6 +89,12 @@ void ViewModifier::run_mod_mp1() {
 }
 
 void ViewModifier::run_mod_mp1_gc() {
+  u8 version = read8(0x80000007);
+
+  if (version != 0) {
+    return;
+  }
+
   const u16 camera_uid = read16(mp1_gc_static.camera_mgr_address);
   if (camera_uid == -1) {
     return;
@@ -221,7 +227,7 @@ void ViewModifier::init_mod(Game game, Region region) {
     init_mod_mp3(region);
     break;
   case Game::PRIME_3_STANDALONE:
-    init_mod_mp3_wii(region);
+    init_mod_mp3_standalone(region);
     break;
   }
   initialized = true;
@@ -256,13 +262,17 @@ void ViewModifier::init_mod_mp1(Region region) {
 }
 
 void ViewModifier::init_mod_mp1_gc(Region region) {
+  u8 version = PowerPC::HostRead_U8(0x80000007);
+
   if (region == Region::NTSC_U) {
-    mp1_gc_static.camera_mgr_address = 0x8045c5b4;
-    mp1_gc_static.object_list_address = 0x8045a9b8;
-    mp1_gc_static.global_fov1_table_off = -0x7ff0;
-    mp1_gc_static.global_fov2_table_off = -0x7fec;
-    mp1_gc_static.gun_pos_address = 0x8045bce8;
-    mp1_gc_static.culling_address = 0x80337a24;
+    if (version == 0) {
+      mp1_gc_static.camera_mgr_address = 0x8045c5b4;
+      mp1_gc_static.object_list_address = 0x8045a9b8;
+      mp1_gc_static.global_fov1_table_off = -0x7ff0;
+      mp1_gc_static.global_fov2_table_off = -0x7fec;
+      mp1_gc_static.gun_pos_address = 0x8045bce8;
+      mp1_gc_static.culling_address = 0x80337a24;
+    }
   }
   else if (region == Region::PAL) {
     //statemgr 803e2088
@@ -334,11 +344,16 @@ void ViewModifier::init_mod_mp3(Region region) {
   else {}
 }
   
-void ViewModifier::init_mod_mp3_wii(Region region) {
+void ViewModifier::init_mod_mp3_standalone(Region region) {
   if (region == Region::NTSC_U) {
     mp3_static.camera_ptr_address = 0x805c4f94;
     mp3_static.tweakgun_address = 0x8067d78c;
     mp3_static.culling_address = 0x80316a1c;
+  }
+  else if (region == Region::NTSC_J) {
+    mp3_static.camera_ptr_address = 0x805caa58;
+    mp3_static.tweakgun_address = 0x806835fc;
+    mp3_static.culling_address = 0x8031a4b4;
   }
   else if (region == Region::PAL) {
     mp3_static.camera_ptr_address = 0x805c7598;

--- a/Source/Core/Core/PrimeHack/Mods/ViewModifier.h
+++ b/Source/Core/Core/PrimeHack/Mods/ViewModifier.h
@@ -33,7 +33,7 @@ private:
   void init_mod_mp2(Region region);
   void init_mod_mp2_gc(Region region);
   void init_mod_mp3(Region region);
-  void init_mod_mp3_wii(Region region);
+  void init_mod_mp3_standalone(Region region);
 
   union {
     struct {


### PR DESCRIPTION
Added ContextSensitiveControls mod support for MP3 Standalone NTSC-J/U and PAL
Added beam/visor implementation for MP3 Standalone NTSC-J/U and PAL
Added beam/visor implementation for NPC MP1/2 NTSC-J
Fixed cursor not being centered on NPC MP2 NTSC-J
Fixed cursor self centering on X axis on NPC MP2 NTSC-J menu
Implemented skip cutscene for MP1 GC NTSC-U 0-02
Now parsing the version of MP1 GC NTSC-U