### PR TITLE
Tons of fixes for MP3 Standalone

### DIFF
--- a/Source/Core/Core/PrimeHack/AddressDBInit.cpp
+++ b/Source/Core/Core/PrimeHack/AddressDBInit.cpp
@@ -128,33 +128,36 @@ void init_db(AddressDB& addr_db) {
   addr_db.register_dynamic_address(Game::PRIME_3, "firstperson_pitch", "player", {mrt1(0x784)});
   addr_db.register_dynamic_address(Game::PRIME_3, "active_visor", "powerups_array", {mrt1(0x34)});
   addr_db.register_dynamic_address(Game::PRIME_3, "beamvisor_menu_state", "beamvisor_menu_base", {rt0, mrt1(0x300)});
+  addr_db.register_dynamic_address(Game::PRIME_3, "lockon_type", "player", { mrt1(0x370) });
   addr_db.register_dynamic_address(Game::PRIME_3, "grapple_state", "player", {mrt1(0x378)});
   addr_db.register_dynamic_address(Game::PRIME_3, "angular_momentum", "player", {mrt1(0x174)});
   addr_db.register_dynamic_address(Game::PRIME_3, "ball_state", "player", {mrt1(0x358)});
 
   addr_db.register_address(Game::PRIME_3_STANDALONE, "state_manager", 0x805c4f98, 0x805c7598, 0x805caa58); // +0x1010 object list
-  addr_db.register_address(Game::PRIME_3_STANDALONE, "tweakgun", 0x8067d78c, 0x8067fdac, 0x806835fc);
+  addr_db.register_address(Game::PRIME_3_STANDALONE, "tweakgun", 0x8067d78c, 0x8067fdb4, 0x806835fc);
   addr_db.register_address(Game::PRIME_3_STANDALONE, "motion_vf", 0x802e2508, 0x802e3be4, 0x802e5ed8);
   addr_db.register_address(Game::PRIME_3_STANDALONE, "cursor_base", 0x8067dc18, 0x80680240, 0x80683a88);
   addr_db.register_address(Game::PRIME_3_STANDALONE, "cursor_dlg_enabled", 0x805c70c7, 0x805c96df, 0x805ccbd7);
-  addr_db.register_address(Game::PRIME_3_STANDALONE, "boss_info_base", 0x8067c0e4, 0x8067c87c, 0x80681f54);
+  addr_db.register_address(Game::PRIME_3_STANDALONE, "boss_info_base", 0x8067c0e4, 0x8067e70c, 0x80681f54);
   addr_db.register_address(Game::PRIME_3_STANDALONE, "beamvisor_menu_base", 0x8067dc0c, 0x80680234, 0x80683a7c);
   addr_db.register_address(Game::PRIME_3_STANDALONE, "lockon_state", 0x805c50e7, 0x805c76e7, 0x805caba7);
-  addr_db.register_address(Game::PRIME_3_STANDALONE, "gun_lag_toc_offset", -0x5fb0, -0x6000, -0x5f68);
+  addr_db.register_address(Game::PRIME_3_STANDALONE, "gun_lag_toc_offset", -0x5fb0, -0x5f98, -0x5f68);
   addr_db.register_address(Game::PRIME_3_STANDALONE, "powerups_size", 12, 12, 12);
   addr_db.register_address(Game::PRIME_3_STANDALONE, "powerups_offset", 0x58, 0x58, 0x58);
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "camera_manager", "state_manager", {mrt1(0x10), mrt1(0xc), mrt1(0x16)});
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "perspective_info", "camera_manager", {mrt1(0x2), mrt1(0x14), rt0});
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "object_list", "state_manager", {rt0, mrt1(0x1010), rt0});
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "player", "state_manager", {rt0, mrt1(0x2184), rt0});
-  addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "cursor", "cursor_base", {rt0, rt(0xc54, 0xd04, 0xc54), rt0});
-  addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "powerups_array", "player", {rt(0x35a0, 0x35a8, 0x35a0), rt0});
+  addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "cursor", "cursor_base", {rt0, mrt1(0xc54), rt0});
+  addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "powerups_array", "player", {rt(0x35a0, 0x35a0, 0x35a8), rt0});
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "boss_name", "boss_info_base", {rt0, mrt1(0x6e0), mrt1(0x24), mrt1(0x150), rt0});
+  addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "boss_status", "boss_info_base", { rt0, mrt1(0x6e0), mrt1(0x24), mrt1(0xb3) });
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "firstperson_pitch", "player", {rt(0x77c, 0x77c, 0x784)});
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "beamvisor_menu_state", "beamvisor_menu_base", {rt0, mrt1(0x1708)});
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "active_visor", "powerups_array", {mrt1(0x34)});
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "angular_momentum", "player", {mrt1(0x174)});
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "ball_state", "player", {mrt1(0x358)});
-  addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "grapple_state", "player", {mrt1(0x378)});
+  addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "lockon_type", "player", { mrt1(0x370) });
+  addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "grapple_state", "player", {rt(0, 0x378, 0x378)});
 }
 }

--- a/Source/Core/Core/PrimeHack/HackManager.cpp
+++ b/Source/Core/Core/PrimeHack/HackManager.cpp
@@ -100,10 +100,6 @@ void HackManager::run_active_mods() {
       active_game = Game::PRIME_2_GCN;
       active_region = Region::NTSC_U;
     }
-    else if (region_code == FOURCC('R', 'M', '3', 'J')) {
-      active_game = Game::PRIME_3_STANDALONE;
-      active_region = Region::NTSC_J;
-    }
     else if (region_code == FOURCC('G', '2', 'M', 'P')) {
       active_game = Game::PRIME_2_GCN;
       active_region = Region::PAL;
@@ -111,6 +107,10 @@ void HackManager::run_active_mods() {
     else if (region_code == FOURCC('R', 'M', '3', 'E')) {
       active_game = Game::PRIME_3_STANDALONE;
       active_region = Region::NTSC_U;
+    }
+    else if (region_code == FOURCC('R', 'M', '3', 'J')) {
+      active_game = Game::PRIME_3_STANDALONE;
+      active_region = Region::NTSC_J;
     }
     else if (region_code == FOURCC('R', 'M', '3', 'P')) {
       active_game = Game::PRIME_3_STANDALONE;

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
@@ -23,18 +23,20 @@ const std::array<std::tuple<int, int>, 4> prime_three_visors = {
   std::make_tuple<int, int>(2, 0x0d), std::make_tuple<int, int>(3, 0x0e)};
 
 constexpr u32 ORBIT_STATE_GRAPPLE = 5;
+#define RIDLEY_STR(r) (r == Region::NTSC_J ? L"メタリドリー" : L"Meta Ridley")
+#define RIDLEY_STR_LEN(r) (r == Region::NTSC_J ? 6 : 11)
 
-bool is_string_ridley(u32 string_base) {
+bool is_string_ridley(Region active_region, u32 string_base) {
   if (string_base == 0) {
     return false;
   }
 
-  const char ridley_str[] = "Meta Ridley";
-  constexpr auto str_len = sizeof(ridley_str) - 1;
+  const wchar_t * ridley_str = RIDLEY_STR(active_region);
+  const auto str_len = RIDLEY_STR_LEN(active_region);
   int str_idx = 0;
 
   while (read16(string_base) != 0 && str_idx < str_len) {
-    if (static_cast<char>(read16(string_base)) != ridley_str[str_idx]) {
+    if (static_cast<wchar_t>(read16(string_base)) != ridley_str[str_idx]) {
       return false;
     }
     str_idx++;
@@ -528,7 +530,7 @@ void FpsControls::mp3_handle_cursor(bool lock) {
 }
 
 
-void FpsControls::mp3_handle_lasso(u32 grapple_state_addr)
+void FpsControls::mp3_handle_lasso(bool is_using_grapple_lasso_or_voltage)
 {
   if (GrappleCtlBound()) {
     set_code_group_state("grapple_lasso", ModState::ENABLED);
@@ -543,7 +545,11 @@ void FpsControls::mp3_handle_lasso(u32 grapple_state_addr)
   }
 
   // If currently locked onto a grapple point. This must be seperate from lock-on for grapple swing.
-  if (read8(grapple_state_addr)) {
+  // On US Standalone we check at 0x370 which is the lock type because 0x378 isn't existing in that version
+  // 1 => Locked On
+  // 2 => Grapple Lasso(/Voltage)
+  // 3 => Grapple Swing
+  if (is_using_grapple_lasso_or_voltage) {
     if (grapple_initial_cooldown == 0) {
       grapple_initial_cooldown = Common::Timer::GetTimeMs();
     }
@@ -601,6 +607,7 @@ void FpsControls::mp3_handle_lasso(u32 grapple_state_addr)
 
 // this game is
 void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
+  const bool is_mp3_standalone_us = hack_mgr->get_active_game() == Game::PRIME_3_STANDALONE && hack_mgr->get_active_region() == Region::NTSC_U;
   CheckBeamVisorSetting(active_game);
 
   if (GrappleCtlBound()) {
@@ -625,8 +632,8 @@ void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
   // In NTSC-J version there is a quiz to select the difficulty
   // This checks if we are ingame
   LOOKUP(state_manager);
-  // I won't add (state_manager + 0x298) to the address db, not sure what it is
-  if (active_region == Region::NTSC_J && read32(state_manager + 0x298) == 0xffffffff) {
+  // I won't add (state_manager + 0x29C) to the address db, not sure what it is
+  if (active_region == Region::NTSC_J && read32(state_manager + 0x29C) == 0xffffffff) {
     mp3_handle_cursor(false);
     return;
   }
@@ -640,22 +647,20 @@ void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
   handle_beam_visor_switch({}, prime_three_visors);
 
   LOOKUP_DYN(boss_name);
-  bool is_boss_metaridley = is_string_ridley(boss_name);
+  LOOKUP_DYN(boss_status);
+  bool is_boss_metaridley = is_string_ridley(active_region, boss_name);
 
   // Compare based on boss name string, Meta Ridley only appears once
   if (is_boss_metaridley) {
-    if (!fighting_ridley) {
-      fighting_ridley = true;
-      set_state(ModState::CODE_DISABLED);
-    }
-    mp3_handle_cursor(false);
-    return;
-  } else {
-    if (fighting_ridley) {
-      fighting_ridley = false;
+    // if boss has died
+    if (read8(boss_status) == 10) {
       set_state(ModState::ENABLED);
+      mp3_handle_cursor(true);
+    } else {
+      set_state(ModState::CODE_DISABLED);
+      mp3_handle_cursor(false);
+      return;
     }
-    mp3_handle_cursor(true);
   }
 
   prime::GetVariableManager()->set_variable("trigger_grapple", prime::CheckGrappleCtl() ? u32{1} : u32{0});
@@ -664,11 +669,13 @@ void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
   LOOKUP_DYN(angular_momentum);
   LOOKUP_DYN(beamvisor_menu_state);
   LOOKUP_DYN(grapple_state);
+  LOOKUP_DYN(lockon_type);
   LOOKUP(lockon_state);
+  bool is_using_any_grapple = is_mp3_standalone_us ? read32(lockon_type) > 1 : read8(grapple_state);
   bool beamvisor_menu = read32(beamvisor_menu_state) == 3;
-  if (!read8(grapple_state) && read8(lockon_state) || beamvisor_menu) {
+  if (!is_using_any_grapple && read8(lockon_state) || beamvisor_menu) {
     write32(0, angular_momentum);
-    calculate_pitch_locked(Game::PRIME_3, active_region);
+    calculate_pitch_locked(active_game, active_region);
 
     if (HandleReticleLockOn() || beamvisor_menu) {
       mp3_handle_cursor(false);
@@ -680,7 +687,7 @@ void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
   }
 
   // Handle grapple lasso bind
-  mp3_handle_lasso(grapple_state);
+  mp3_handle_lasso(is_mp3_standalone_us ? read32(lockon_type) == 2 : read8(grapple_state));
 
   // Lock Camera according to ContextSensitiveControls and interpolate to pitch 0
   if (prime::GetLockCamera() != Unlocked) {
@@ -704,6 +711,7 @@ void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
 
   calculate_pitch_delta();
   // Gun damping uses its own TOC value, so screw it (I checked the binary)
+  // Byte pattern to find the offset : c0?2???? ec23082a fc60f850
   LOOKUP(gun_lag_toc_offset);
   u32 rtoc_gun_damp = GPR(2) + gun_lag_toc_offset;
   write32(0, rtoc_gun_damp);
@@ -1645,6 +1653,10 @@ void FpsControls::init_mod_mp3(Region region) {
 }
 
 void FpsControls::init_mod_mp3_standalone(Region region) {
+  prime::GetVariableManager()->register_variable("grapple_lasso_state");
+  prime::GetVariableManager()->register_variable("grapple_hand_x");
+  prime::GetVariableManager()->register_variable("grapple_hand_y");
+  prime::GetVariableManager()->register_variable("trigger_grapple");
   prime::GetVariableManager()->register_variable("new_beam");
   prime::GetVariableManager()->register_variable("beamchange_flag");
   if (region == Region::NTSC_U) {
@@ -1659,6 +1671,9 @@ void FpsControls::init_mod_mp3_standalone(Region region) {
     add_code_change(0x80183288, 0x60000000);
 
     add_code_change(0x800617e4, 0x60000000, "visor_menu");
+
+    // Grapple Lasso
+    add_grapple_lasso_code_mp3(0x800DF790, 0x80174D70, 0x80175B54);
 
     add_control_state_hook_mp3(0x80005880, Region::NTSC_U);
     add_grapple_slide_code_mp3(0x80182c9c);
@@ -1675,6 +1690,9 @@ void FpsControls::init_mod_mp3_standalone(Region region) {
 
     add_code_change(0x80075f0c, 0x80061958, "visor_menu");
 
+    // Grapple Lasso
+    add_grapple_lasso_code_mp3(0x800E003C, 0x80176B20, 0x80177908);
+
     add_control_state_hook_mp3(0x80005880, Region::NTSC_J);
     add_grapple_slide_code_mp3(0x801849e8);
   } else if (region == Region::PAL) {
@@ -1689,6 +1707,9 @@ void FpsControls::init_mod_mp3_standalone(Region region) {
     add_code_change(0x80183dc8, 0x60000000);
 
     add_code_change(0x80061a88, 0x60000000, "visor_menu");
+
+    // Grapple Lasso
+    add_grapple_lasso_code_mp3(0x800DFC4C, 0x80175914, 0x801766FC);
 
     add_control_state_hook_mp3(0x80005880, Region::PAL);
     add_grapple_slide_code_mp3(0x801837dc);

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.h
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.h
@@ -30,7 +30,7 @@ private:
   void handle_beam_visor_switch(std::array<int, 4> const &beams,
                                 std::array<std::tuple<int, int>, 4> const& visors);
   void mp3_handle_cursor(bool lock);
-  void mp3_handle_lasso(u32 grapple_state_addr);
+  void mp3_handle_lasso(bool is_using_grapple_lasso_or_voltage);
 
   void run_mod_menu(Game game, Region region);
   void run_mod_mp1(Region region);

--- a/Source/Core/Core/PrimeHack/Mods/RestoreDashing.h
+++ b/Source/Core/Core/PrimeHack/Mods/RestoreDashing.h
@@ -20,9 +20,11 @@ namespace prime {
           // restore dashing speed
           add_code_change(0x80194b60, 0x4800001c);
           // stop dash when done dashing
-          add_code_change(0x80192cc0, 0x801f037c); // CPlayer + 0x37c
+          add_code_change(0x80192cc0, 0x881f037c); // CPlayer + 0x37c
         } else if (region == Region::PAL) {
+          // remove scan visor check
           add_code_change(0x801935cc, 0x48000018);
+          // restore dashing speed
           add_code_change(0x80194df8, 0x4800001c);
           // stop dash when done dashing
           add_code_change(0x80192f58, 0x881f037c); // CPlayer + 0x37c
@@ -30,6 +32,7 @@ namespace prime {
         else { // region == Region::NTSC-J
           // remove scan visor check
           add_code_change(0x80193eb4, 0x48000018);
+          // restore dashing speed
           add_code_change(0x801956e0, 0x4800001c);
           // stop dash when done dashing
           add_code_change(0x80193840, 0x881f037c); // CPlayer + 0x37c
@@ -37,10 +40,13 @@ namespace prime {
         break;
       case Game::PRIME_1_GCN:
         if (region == Region::NTSC_U && version == 2) {
+          // remove scan visor check
           add_code_change(0x802888d0, 0x48000018);
         } else if (region == Region::PAL) {
+          // remove scan visor check
           add_code_change(0x80275328, 0x48000018);
         } else if (region == Region::NTSC_J) {
+          // remove scan visor check
           add_code_change(0x802770e4, 0x48000018);
         }
         break;
@@ -51,11 +57,15 @@ namespace prime {
           // stop dash when done dashing
           add_code_change(0x8015cd1c, 0x881e0574); // CPlayer + 0x574 as u8
         } else if (region == Region::NTSC_J) {
+          // don't slow down when finishing the dash
           add_code_change(0x8015cc58, 0x60000000);
-          add_code_change(0x8015c2e4, 0x881e0574);
+          // stop dash when done dashing
+          add_code_change(0x8015c2e4, 0x881e0574); // CPlayer + 0x588 as u8
         } else if (region == Region::PAL) {
+          // don't slow down when finishing the dash
           add_code_change(0x8015ee08, 0x60000000);
-          add_code_change(0x8015e494, 0x881e0574);
+          // stop dash when done dashing
+          add_code_change(0x8015e494, 0x881e0574); // CPlayer + 0x588 as u8
         }
         break;
       case Game::PRIME_2_GCN:
@@ -65,11 +75,15 @@ namespace prime {
           // stop dash when done dashing
           add_code_change(0x80189d6c, 0x881e0588); // CPlayer + 0x588 as u8
         } else if (region == Region::NTSC_J) {
+          // don't slow down when finishing the dash
           add_code_change(0x8018b130, 0x60000000);
-          add_code_change(0x8018b884, 0x881e0588);
+          // stop dash when done dashing
+          add_code_change(0x8018b884, 0x881e0588); // CPlayer + 0x588 as u8
         } else if (region == Region::PAL) {
+          // don't slow down when finishing the dash
           add_code_change(0x80189914, 0x60000000);
-          add_code_change(0x8018a068, 0x881e0588);
+          // stop dash when done dashing
+          add_code_change(0x8018a068, 0x881e0588); // CPlayer + 0x588 as u8
         }
         break;
       case Game::PRIME_3:
@@ -77,10 +91,12 @@ namespace prime {
           // don't slow down when finishing the dash
           add_code_change(0x80174c60, 0x60000000);
           // stop dash when done dashing
-          add_code_change(0x8017432c, 0x881e06cc); // CPlayer + 0x6cc as u8
+          add_code_change(0x8017432c, 0x881e06d0); // CPlayer + 0x6d0 as u8
         } else if (region == Region::PAL) {
+          // don't slow down when finishing the dash
           add_code_change(0x801745ac, 0x60000000);
-          add_code_change(0x80173c78, 0x881e06cc);
+          // stop dash when done dashing
+          add_code_change(0x80173c78, 0x881e06d0); // CPlayer + 0x6d0 as u8
         }
         break;
       case Game::PRIME_3_STANDALONE:
@@ -90,11 +106,15 @@ namespace prime {
           // stop dash when done dashing
           add_code_change(0x8017845c, 0x881e06cc); // CPlayer + 0x6cc as u8
         } else if (region == Region::NTSC_J) {
+          // don't slow down when finishing the dash
           add_code_change(0x8017aa90, 0x60000000);
-          add_code_change(0x8017a15c, 0x881e06cc);
+          // stop dash when done dashing
+          add_code_change(0x8017a15c, 0x881e06d0); // CPlayer + 0x6d0 as u8
         } else if (region == Region::PAL) {
+          // don't slow down when finishing the dash
           add_code_change(0x80179884, 0x60000000);
-          add_code_change(0x80178F50, 0x881e06cc);
+          // stop dash when done dashing
+          add_code_change(0x80178F50, 0x881e06d0); // CPlayer + 0x6d0 as u8
         }
         break;
       }

--- a/Source/Core/Core/PrimeHack/Mods/ViewModifier.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/ViewModifier.cpp
@@ -27,6 +27,7 @@ void ViewModifier::run_mod(Game game, Region region) {
 }
 
 void ViewModifier::adjust_viewmodel(float fov, u32 arm_address, u32 znear_address, u32 znear_value) {
+  bool is_mp3_standalone_us = hack_mgr->get_active_game() == Game::PRIME_3_STANDALONE && hack_mgr->get_active_region() == Region::NTSC_U;
   float left = 0.25f;
   float forward = 0.30f;
   float up = -0.35f;
@@ -38,10 +39,17 @@ void ViewModifier::adjust_viewmodel(float fov, u32 arm_address, u32 znear_addres
         left = 0.22f;
         forward = -0.02f;
         apply_znear = true;
+        if (is_mp3_standalone_us) {
+          forward = 0.05f;
+          up = -0.36f;
+        }
       } else if (fov >= 75) {
         float factor = (fov - 75) / (125 - 75);
         left = Lerp(left, 0.22f, factor);
         forward = Lerp(forward, -0.02f, factor);
+        if (is_mp3_standalone_us) {
+          up = Lerp(up, -0.48f, factor);
+        }
         apply_znear = true;
       }
     } else {
@@ -349,12 +357,18 @@ void ViewModifier::init_mod_mp3(Region region) {
   
 void ViewModifier::init_mod_mp3_standalone(Region region) {
   if (region == Region::NTSC_U) {
+    add_code_change(0x8007f504, 0x60000000);
+    add_code_change(0x8009cfc4, 0x60000000);
     add_code_change(0x80316a1c, 0x38600001, "culling");
     add_code_change(0x80316a1c + 0x4, 0x4e800020, "culling");
   } else if (region == Region::PAL) {
+    add_code_change(0x8007f7a0, 0x60000000);
+    add_code_change(0x8009d41c, 0x60000000);
     add_code_change(0x80318170, 0x38600001, "culling");
     add_code_change(0x80318170 + 0x4, 0x4e800020, "culling");
   } else if (region == Region::NTSC_J) {
+    add_code_change(0x8007f934, 0x60000000);
+    add_code_change(0x8009d5b0, 0x60000000);
     add_code_change(0x8031a4b4, 0x38600001, "culling");
     add_code_change(0x8031a4b4 + 0x4, 0x4e800020, "culling");
   }


### PR DESCRIPTION
Reordering games in HackManager::run_active_mods()
Fixed all MP3 versions of restore dashing mod
Fixed MP1 Trilogy US restore dashing mod
Added support for japanese version of Meta Ridley boss detection
Modified FpsControls::mp3_handle_lasso() to handle US Standalone version as it's missing a class member in CPlayer
Fixed quiz detection offset it now detects it properly
Fixed Meta Ridley boss post fight reset (Now it detects properly the end of the fight)
Added support for Grapple Lasso code for MP3 Standalone
Fixed FOV stuff for US and PAL Standalone versions
Added lockon type for MP3 Standalone to the address DB
Fixed powerups array for PAL and JAP version of MP3 Standalone (PAL <=> JAP)
Fixed cursor for PAL version of MP3 Standalone
Fixed boss info base for PAL version of MP3 Standalone
Added boss status for each MP3 version to the address DB
Fixed gun lag toc offsets for MP3 Standalone
Fixed tweakgun for PAL version of MP3 Standalone
Updated disable culling mod to the latest modifications of MP3 Trilogy