### PR TITLE
Added support to unsupported versions

### DIFF
--- a/Source/Core/Core/PrimeHack/AddressDBInit.cpp
+++ b/Source/Core/Core/PrimeHack/AddressDBInit.cpp
@@ -61,6 +61,8 @@ void init_db(AddressDB& addr_db) {
   addr_db.register_dynamic_address(Game::PRIME_1_GCN, "angular_vel", "player", {rt(0x14c, 0x15c, 0)});
   addr_db.register_dynamic_address(Game::PRIME_1_GCN, "firstperson_pitch", "player", {rt(0x3ec, 0x3fc, 0)});
   addr_db.register_dynamic_address(Game::PRIME_1_GCN, "ball_state", "player", {rt(0x2f4, 0x304, 0)});
+  addr_db.register_dynamic_address(Game::PRIME_1_GCN, "freelook_rotation_speed", "tweak_player", { mrt1(0x280) });
+  addr_db.register_dynamic_address(Game::PRIME_1_GCN, "air_transitional_friction", "tweak_player", { mrt1(0x180) });
 
   // object list = state mgr + x810
   // camera mgr = state mgr + x870
@@ -100,14 +102,14 @@ void init_db(AddressDB& addr_db) {
   addr_db.register_dynamic_address(Game::PRIME_2, "area_layers_vector", "state_manager", {mrt1(0x1e38), mrt1(0x8), rt0});
 
 
-  addr_db.register_address(Game::PRIME_2_GCN, "state_manager", 0x803db6e0, 0x803dc900);
-  addr_db.register_address(Game::PRIME_2_GCN, "tweakgun_offset", -0x6e1c, -0x6e14);
-  addr_db.register_address(Game::PRIME_2_GCN, "tweak_player_offset", -0x6e3c, -0x6e34);
-  addr_db.register_address(Game::PRIME_2_GCN, "tweakgui_offset", -0x6e20, -0x6e18);
-  addr_db.register_address(Game::PRIME_2_GCN, "conn_vec_offset", 0x14, 0x14);
-  addr_db.register_address(Game::PRIME_2_GCN, "seq_timer_vec_offset", 0x3c, 0x3c);
-  addr_db.register_address(Game::PRIME_2_GCN, "seq_timer_fire_size", 0x18, 0x18);
-  addr_db.register_address(Game::PRIME_2_GCN, "seq_timer_time_offset", 0x10, 0x10);
+  addr_db.register_address(Game::PRIME_2_GCN, "state_manager", 0x803db6e0, 0x803dc900, 0x803de690);
+  addr_db.register_address(Game::PRIME_2_GCN, "tweakgun_offset", -0x6e1c, -0x6e14, -0x6ddc);
+  addr_db.register_address(Game::PRIME_2_GCN, "tweak_player_offset", -0x6e3c, -0x6e34, -0x6dfc);
+  addr_db.register_address(Game::PRIME_2_GCN, "tweakgui_offset", -0x6e20, -0x6e18, -0x6de0);
+  addr_db.register_address(Game::PRIME_2_GCN, "conn_vec_offset", 0x14, 0x14, 0x14);
+  addr_db.register_address(Game::PRIME_2_GCN, "seq_timer_vec_offset", 0x3c, 0x3c, 0x3c);
+  addr_db.register_address(Game::PRIME_2_GCN, "seq_timer_fire_size", 0x18, 0x18, 0x18);
+  addr_db.register_address(Game::PRIME_2_GCN, "seq_timer_time_offset", 0x10, 0x10, 0x10);
   addr_db.register_dynamic_address(Game::PRIME_2_GCN, "camera_manager", "state_manager", {mrt1(0x151c), mrt1(0x14)});
   addr_db.register_dynamic_address(Game::PRIME_2_GCN, "object_list", "state_manager", {mrt1(0x810), rt0});
   addr_db.register_dynamic_address(Game::PRIME_2_GCN, "world", "state_manager", {mrt1(0x1604), rt0});
@@ -155,7 +157,7 @@ void init_db(AddressDB& addr_db) {
   addr_db.register_address(Game::PRIME_3_STANDALONE, "state_manager", 0x805c4f98, 0x805c7598, 0x805caa58); // +0x1010 object list
   addr_db.register_address(Game::PRIME_3_STANDALONE, "tweakgun", 0x8067d78c, 0x8067fdb4, 0x806835fc);
   addr_db.register_address(Game::PRIME_3_STANDALONE, "motion_vf", 0x802e2508, 0x802e3be4, 0x802e5ed8);
-  addr_db.register_address(Game::PRIME_3_STANDALONE, "dna_scanner_vftable", 0x80599b50);
+  addr_db.register_address(Game::PRIME_3_STANDALONE, "dna_scanner_vftable", 0x80599b50, 0x8059c140, 0x8059f580);
   addr_db.register_address(Game::PRIME_3_STANDALONE, "cursor_base", 0x8067dc18, 0x80680240, 0x80683a88);
   addr_db.register_address(Game::PRIME_3_STANDALONE, "cursor_dlg_enabled", 0x805c70c7, 0x805c96df, 0x805ccbd7);
   addr_db.register_address(Game::PRIME_3_STANDALONE, "boss_info_base", 0x8067c0e4, 0x8067e70c, 0x80681f54);
@@ -164,7 +166,7 @@ void init_db(AddressDB& addr_db) {
   addr_db.register_address(Game::PRIME_3_STANDALONE, "gun_lag_toc_offset", -0x5fb0, -0x5f98, -0x5f68);
   addr_db.register_address(Game::PRIME_3_STANDALONE, "powerups_size", 12, 12, 12);
   addr_db.register_address(Game::PRIME_3_STANDALONE, "powerups_offset", 0x58, 0x58, 0x58);
-  addr_db.register_address(Game::PRIME_3_STANDALONE, "bloom_offset", 0x80589410);
+  addr_db.register_address(Game::PRIME_3_STANDALONE, "bloom_offset", 0x80589410, 0x8058b9d8, 0x8058edd8);
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "camera_manager", "state_manager", {mrt1(0x10), mrt1(0xc), mrt1(0x16)});
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "perspective_info", "camera_manager", {mrt1(0x2), mrt1(0x14), rt0});
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "object_list", "state_manager", {rt0, mrt1(0x1010), rt0});

--- a/Source/Core/Core/PrimeHack/HackManager.cpp
+++ b/Source/Core/Core/PrimeHack/HackManager.cpp
@@ -100,6 +100,10 @@ void HackManager::run_active_mods() {
       active_game = Game::PRIME_2_GCN;
       active_region = Region::NTSC_U;
     }
+    else if (region_code == FOURCC('G', '2', 'M', 'J')) {
+      active_game = Game::PRIME_2_GCN;
+      active_region = Region::NTSC_J;
+    }
     else if (region_code == FOURCC('G', '2', 'M', 'P')) {
       active_game = Game::PRIME_2_GCN;
       active_region = Region::PAL;

--- a/Source/Core/Core/PrimeHack/Mods/ContextSensitiveControls.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/ContextSensitiveControls.cpp
@@ -128,10 +128,18 @@ bool ContextSensitiveControls::init_mod(Game game, Region region) {
       add_code_change(0x801fdb5c, lis);
       add_code_change(0x801fdb64, ori);
       add_code_change(0x801fdb6c, lfs);
+
+      add_code_change(0x801ffd7c, lis);
+      add_code_change(0x801ffd80, ori);
+      add_code_change(0x801ffd84, lfs);
     } else if (region == Region::PAL) {
       add_code_change(0x801fc5a8, lis);
       add_code_change(0x801fc5b0, ori);
       add_code_change(0x801fc5b8, lfs);
+
+      add_code_change(0x801fe7c8, lis);
+      add_code_change(0x801fe7cc, ori);
+      add_code_change(0x801fe7d0, lfs);
     }
     break;
   default:

--- a/Source/Core/Core/PrimeHack/Mods/DisableHudMemoPopup.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/DisableHudMemoPopup.cpp
@@ -85,6 +85,10 @@ void DisableHudMemoPopup::init_mod_mp1(Region region) {
     add_code_change(0x801ed734, 0x48000018);
     add_code_change(0x801ed75c, vmc_fix_time);
     add_code_change(0x801cc964, vmc_fix_justification);
+  } else { // region == Region::NTSC_J
+    add_code_change(0x801ee014, 0x48000018);
+    add_code_change(0x801ee03c, vmc_fix_time);
+    add_code_change(0x801cd208, vmc_fix_justification);
   }
 }
 
@@ -118,7 +122,11 @@ void DisableHudMemoPopup::init_mod_mp3(Game game, Region region) {
   } else if (game == Game::PRIME_3_STANDALONE) {
     if (region == Region::NTSC_U) {
       add_code_change(0x8021fe80, vmc_restart_audio);
-    } else {}
+    } else if (region == Region::PAL) {
+      add_code_change(0x80220f10, vmc_restart_audio);
+    } else { // region == Region::NTSC_J
+      add_code_change(0x8022251c, vmc_restart_audio);
+    }
   }
 }
 
@@ -135,14 +143,18 @@ bool DisableHudMemoPopup::init_mod(Game game, Region region) {
       add_code_change(0x801f3354, 0x48000018);
     } else if  (region == Region::PAL) {
       add_code_change(0x801f586c, 0x48000018);
-    } else {}
+    } else { // region == Region::NTSC_J
+      add_code_change(0x801f2368, 0x48000018);
+    }
     break;
   case Game::PRIME_2_GCN:
     if (region == Region::NTSC_U) {
       add_code_change(0x800bb10c, 0x48000018);
     } else if (region == Region::PAL) {
       add_code_change(0x800bb1a0, 0x48000018);
-    } else {}
+    } else { // region == Region::NTSC_J
+      add_code_change(0x800bbe9c, 0x48000018);
+    }
     break;
   case Game::PRIME_3:
   case Game::PRIME_3_STANDALONE:

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.h
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.h
@@ -35,7 +35,7 @@ private:
   void run_mod_mp1(Region region);
   void run_mod_mp2(Region region);
   void run_mod_mp3(Game game, Region region);
-  void run_mod_mp1_gc();
+  void run_mod_mp1_gc(Region region);
   void run_mod_mp2_gc();
 
   void CheckBeamVisorSetting(Game game);
@@ -66,7 +66,6 @@ private:
 
   // Required due to MP3
   bool has_beams;
-  bool fighting_ridley;
 
   // We store our pitch value interally to have full control over it
   float pitch;

--- a/Source/Core/Core/PrimeHack/Mods/Invulnerability.h
+++ b/Source/Core/Core/PrimeHack/Mods/Invulnerability.h
@@ -47,10 +47,8 @@ public:
         add_code_change(0x8014d258, 0x60000000);
       }
       else {  // region == Region::NTSC-J
-        // This was never tested on a new game
-        //add_code_change(0x8014b0ac, 0x3c60804e);
-        //add_code_change(0x8014b0b0, 0x38633cf8);
-        //add_code_change(0x8014b0b4, 0x4e800020);
+        add_code_change(0x8014b0d4, 0x4800000c);
+        add_code_change(0x8014b0ec, 0x60000000);
       }
       break;
     case Game::PRIME_2_GCN:
@@ -58,8 +56,11 @@ public:
         add_code_change(0x8000ec08, 0x3c60803d);
         add_code_change(0x8000ec0c, 0x6063aa28);
         add_code_change(0x8000ec10, 0x4e800020);
-      }
-      else if (region == Region::PAL) {
+      } else if (region == Region::NTSC_J) {
+        add_code_change(0x8000f624, 0x3c60803d);
+        add_code_change(0x8000f628, 0x6063d9d8);
+        add_code_change(0x8000f62c, 0x4e800020);
+      } else if (region == Region::PAL) {
         add_code_change(0x8000ec4c, 0x3c60803d);
         add_code_change(0x8000ec50, 0x6063bc48);
         add_code_change(0x8000ec54, 0x4e800020);

--- a/Source/Core/Core/PrimeHack/Mods/Noclip.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/Noclip.cpp
@@ -426,6 +426,15 @@ bool Noclip::init_mod(Game game, Region region) {
       add_code_change(0x801865f4, 0xd0210088);
       add_code_change(0x801865f8, 0xd0010078);
       add_code_change(0x801865fc, 0x4bec395d);
+    } else if (region == Region::NTSC_J) {
+      noclip_code_mp2_gc(0x803dfb7c, 0x80420000, 0x8004b6ac);
+      add_code_change(0x801880d8, 0x60000000);
+      add_code_change(0x801880e0, 0x60000000);
+      add_code_change(0x801880e8, 0x60000000);
+      add_code_change(0x801880f0, 0xd0410098);
+      add_code_change(0x801880f4, 0xd0210088);
+      add_code_change(0x801880f8, 0xd0010078);
+      add_code_change(0x801880fc, 0x4bec2939);
     } else if (region == Region::PAL) {
       noclip_code_mp2_gc(0x803dddfc, 0x80420000, 0x8004ad44);
       add_code_change(0x801868bc, 0x60000000);

--- a/Source/Core/Core/PrimeHack/Mods/PortalSkipMP2.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/PortalSkipMP2.cpp
@@ -150,7 +150,10 @@ bool PortalSkipMP2::init_mod(Game game, Region region) {
     } else if (region == Region::PAL) {
       add_code_change(0x801e8e60, fix_vmc, "disable_portal_cutscene");
       add_code_change(0x801e8e74, 0x48000114, "disable_portal_cutscene");
-    } 
+    } else { // region == Region::NTSC_J
+      add_code_change(0x801e5948, fix_vmc, "disable_portal_cutscene");
+      add_code_change(0x801e5950, 0x48000114, "disable_portal_cutscene");
+    }
   } else if (game == Game::PRIME_2_GCN) {
     const int fix_portal_terminal_fn = PowerPC::RegisterVmcall(fix_layer_bits);
     const u32 fix_vmc = gen_vmcall(fix_portal_terminal_fn, 0);
@@ -160,7 +163,10 @@ bool PortalSkipMP2::init_mod(Game game, Region region) {
     } else if (region == Region::PAL) {
       add_code_change(0x800b7228, fix_vmc, "disable_portal_cutscene");
       add_code_change(0x800b7240, 0x48000120, "disable_portal_cutscene");
-    } 
+    } else { // region == Region::NTSC_J
+      add_code_change(0x800b7f24, fix_vmc, "disable_portal_cutscene");
+      add_code_change(0x800b7f3c, 0x48000120, "disable_portal_cutscene");
+    }
   } else {
     return true;
   }

--- a/Source/Core/Core/PrimeHack/Mods/SkipCutscene.h
+++ b/Source/Core/Core/PrimeHack/Mods/SkipCutscene.h
@@ -42,6 +42,8 @@ public:
     case Game::PRIME_2_GCN:
       if (region == Region::NTSC_U) {
         add_return_one(0x80142340);
+      } else if (region == Region::NTSC_J) {
+        add_return_one(0x80143330);
       } else if (region == Region::PAL) {
         add_return_one(0x8014257c);
       }

--- a/Source/Core/Core/PrimeHack/Mods/ViewModifier.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/ViewModifier.cpp
@@ -334,6 +334,10 @@ void ViewModifier::init_mod_mp2_gc(Region region) {
     add_code_change(0x801b0b38, 0x60000000);
     add_code_change(0x802f84c0, 0x38600001, "culling");
     add_code_change(0x802f84c0 + 0x4, 0x4e800020, "culling");
+  } else if (region == Region::NTSC_J) {
+    add_code_change(0x801b28f0, 0x60000000);
+    add_code_change(0x802faa28, 0x38600001, "culling");
+    add_code_change(0x802faa28 + 0x4, 0x4e800020, "culling");
   } else if (region == Region::PAL) {
     add_code_change(0x801b0e44, 0x60000000);
     add_code_change(0x802f8818, 0x38600001, "culling");


### PR DESCRIPTION
- DNA Scanner (MP3 Standalone PAL and NTSC-J)
- Portal Skip (MP2 NTSC-J)
- Hud Memo Removal (New Play Controls! Metroid Prime and MP3 Standalone PAL and NTSC-J)
- Added bounds checking on the reticle removal (MP3 Standalone PAL and NTSC-J)
- Reenabled MP3 Standalone NTSC-J
- Fixed MP1 FPS Controls disabled behavior
- Added MP2 GC NTSC-J support
- Fixed New Player Controls! Metroid Prime 2 invincibility