### PR TITLE
Add functionality for a separate controller profile to be loaded when entering morphball mode.

### DIFF
--- a/Languages/Languages.vcxproj
+++ b/Languages/Languages.vcxproj
@@ -50,6 +50,26 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="po.targets" />
   </ImportGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <PoFiles Include="$(OutDir)\**\*.*" />
   </ItemGroup>

--- a/Languages/Languages.vcxproj
+++ b/Languages/Languages.vcxproj
@@ -52,22 +52,22 @@
   </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ClCompile>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <ClCompile>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/Core/AudioCommon/AudioCommon.vcxproj
+++ b/Source/Core/AudioCommon/AudioCommon.vcxproj
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\VSProps\Base.Macros.props" />
+  <Import Project="$(VSPropsDir)Base.Targets.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{54AA7840-5BEB-4A0C-9452-74BA4CC7FD44}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VSPropsDir)Configuration.StaticLibrary.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VSPropsDir)Base.props" />
+    <Import Project="$(VSPropsDir)PCHUse.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="AudioCommon.cpp" />
+    <ClCompile Include="AudioStretcher.cpp" />
+    <ClCompile Include="CubebStream.cpp" />
+    <ClCompile Include="CubebUtils.cpp" />
+    <ClCompile Include="Mixer.cpp" />
+    <ClCompile Include="NullSoundStream.cpp" />
+    <ClCompile Include="OpenALStream.cpp" />
+    <ClCompile Include="WASAPIStream.cpp" />
+    <ClCompile Include="SurroundDecoder.cpp" />
+    <ClCompile Include="WaveFile.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="AlsaSoundStream.h" />
+    <ClInclude Include="AudioCommon.h" />
+    <ClInclude Include="AudioStretcher.h" />
+    <ClInclude Include="CubebStream.h" />
+    <ClInclude Include="CubebUtils.h" />
+    <ClInclude Include="Enums.h" />
+    <ClInclude Include="Mixer.h" />
+    <ClInclude Include="NullSoundStream.h" />
+    <ClInclude Include="OpenALStream.h" />
+    <ClInclude Include="OpenSLESStream.h" />
+    <ClInclude Include="PulseAudioStream.h" />
+    <ClInclude Include="SoundStream.h" />
+    <ClInclude Include="WASAPIStream.h" />
+    <ClInclude Include="SurroundDecoder.h" />
+    <ClInclude Include="WaveFile.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CoreDir)Common\Common.vcxproj">
+      <Project>{2e6c348c-c75c-4d94-8d1e-9c1fcbf3efe4}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)FreeSurround\FreeSurround.vcxproj">
+      <Project>{8498f2fa-5ca6-4169-9971-de5b1fe6132c}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)soundtouch\SoundTouch.vcxproj">
+      <Project>{ec082900-b4d8-42e9-9663-77f02f6936ae}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -1,0 +1,292 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\VSProps\Base.Macros.props" />
+  <Import Project="$(VSPropsDir)Base.Targets.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{2E6C348C-C75C-4D94-8D1E-9C1FCBF3EFE4}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VSPropsDir)Configuration.StaticLibrary.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VSPropsDir)Base.props" />
+    <Import Project="$(VSPropsDir)PCHUse.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="Align.h" />
+    <ClInclude Include="Analytics.h" />
+    <ClInclude Include="Arm64Emitter.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="ArmCommon.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="Assert.h" />
+    <ClInclude Include="Atomic.h" />
+    <ClInclude Include="Atomic_GCC.h" />
+    <ClInclude Include="Atomic_Win32.h" />
+    <ClInclude Include="BitField.h" />
+    <ClInclude Include="BitSet.h" />
+    <ClInclude Include="BitUtils.h" />
+    <ClInclude Include="BlockingLoop.h" />
+    <ClInclude Include="CDUtils.h" />
+    <ClInclude Include="ChunkFile.h" />
+    <ClInclude Include="CodeBlock.h" />
+    <ClInclude Include="ColorUtil.h" />
+    <ClInclude Include="Common.h" />
+    <ClInclude Include="CommonFuncs.h" />
+    <ClInclude Include="CommonPaths.h" />
+    <ClInclude Include="CommonTypes.h" />
+    <ClInclude Include="Inline.h" />
+    <ClInclude Include="Config\Config.h" />
+    <ClInclude Include="Config\ConfigInfo.h" />
+    <ClInclude Include="Config\Enums.h" />
+    <ClInclude Include="Config\Layer.h" />
+    <ClInclude Include="CPUDetect.h" />
+    <ClInclude Include="DebugInterface.h" />
+    <ClInclude Include="Debug\MemoryPatches.h" />
+    <ClInclude Include="Debug\Threads.h" />
+    <ClInclude Include="Debug\Watches.h" />
+    <ClInclude Include="DynamicLibrary.h" />
+    <ClInclude Include="ENetUtil.h" />
+    <ClInclude Include="Event.h" />
+    <ClInclude Include="File.h" />
+    <ClInclude Include="FileSearch.h" />
+    <ClInclude Include="FileUtil.h" />
+    <ClInclude Include="FixedSizeQueue.h" />
+    <ClInclude Include="Flag.h" />
+    <ClInclude Include="FormatUtil.h" />
+    <ClInclude Include="FPURoundMode.h" />
+    <ClInclude Include="GekkoDisassembler.h" />
+    <ClInclude Include="GL\GLExtensions\AMD_pinned_memory.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_blend_func_extended.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_buffer_storage.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_clip_control.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_compute_shader.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_copy_image.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_debug_output.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_draw_elements_base_vertex.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_ES2_compatibility.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_ES3_compatibility.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_framebuffer_object.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_get_program_binary.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_map_buffer_range.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_occlusion_query2.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_sampler_objects.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_sample_shading.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_shader_image_load_store.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_shader_storage_buffer_object.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_sync.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_texture_compression_bptc.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_texture_multisample.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_texture_storage.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_texture_storage_multisample.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_uniform_buffer_object.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_vertex_array_object.h" />
+    <ClInclude Include="GL\GLExtensions\ARB_viewport_array.h" />
+    <ClInclude Include="GL\GLExtensions\EXT_texture_compression_s3tc.h" />
+    <ClInclude Include="GL\GLExtensions\EXT_texture_filter_anisotropic.h" />
+    <ClInclude Include="GL\GLExtensions\GLExtensions.h" />
+    <ClInclude Include="GL\GLExtensions\gl_1_1.h" />
+    <ClInclude Include="GL\GLExtensions\gl_1_2.h" />
+    <ClInclude Include="GL\GLExtensions\gl_1_3.h" />
+    <ClInclude Include="GL\GLExtensions\gl_1_4.h" />
+    <ClInclude Include="GL\GLExtensions\gl_1_5.h" />
+    <ClInclude Include="GL\GLExtensions\gl_2_0.h" />
+    <ClInclude Include="GL\GLExtensions\gl_2_1.h" />
+    <ClInclude Include="GL\GLExtensions\gl_3_0.h" />
+    <ClInclude Include="GL\GLExtensions\gl_3_1.h" />
+    <ClInclude Include="GL\GLExtensions\gl_3_2.h" />
+    <ClInclude Include="GL\GLExtensions\gl_4_2.h" />
+    <ClInclude Include="GL\GLExtensions\gl_4_3.h" />
+    <ClInclude Include="GL\GLExtensions\gl_4_4.h" />
+    <ClInclude Include="GL\GLExtensions\gl_4_5.h" />
+    <ClInclude Include="GL\GLExtensions\gl_common.h" />
+    <ClInclude Include="GL\GLExtensions\HP_occlusion_test.h" />
+    <ClInclude Include="GL\GLExtensions\KHR_debug.h" />
+    <ClInclude Include="GL\GLExtensions\NV_depth_buffer_float.h" />
+    <ClInclude Include="GL\GLExtensions\NV_occlusion_query_samples.h" />
+    <ClInclude Include="GL\GLExtensions\NV_primitive_restart.h" />
+    <ClInclude Include="GL\GLContext.h">
+      <ExcludedFromBuild Condition="'$(Platform)'=='ARM64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="GL\GLInterface\WGL.h">
+      <ExcludedFromBuild Condition="'$(Platform)'=='ARM64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="GL\GLUtil.h">
+      <ExcludedFromBuild Condition="'$(Platform)'=='ARM64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="FloatUtils.h" />
+    <ClInclude Include="Hash.h" />
+    <ClInclude Include="HttpRequest.h" />
+    <ClInclude Include="Image.h" />
+    <ClInclude Include="IniFile.h" />
+    <ClInclude Include="JitRegister.h" />
+    <ClInclude Include="Lazy.h" />
+    <ClInclude Include="LdrWatcher.h" />
+    <ClInclude Include="LinearDiskCache.h" />
+    <ClInclude Include="MathUtil.h" />
+    <ClInclude Include="Matrix.h" />
+    <ClInclude Include="MD5.h" />
+    <ClInclude Include="MemArena.h" />
+    <ClInclude Include="MemoryUtil.h" />
+    <ClInclude Include="MinizipUtil.h" />
+    <ClInclude Include="MsgHandler.h" />
+    <ClInclude Include="NandPaths.h" />
+    <ClInclude Include="Network.h" />
+    <ClInclude Include="PcapFile.h" />
+    <ClInclude Include="Profiler.h" />
+    <ClInclude Include="QoSSession.h" />
+    <ClInclude Include="Random.h" />
+    <ClInclude Include="Result.h" />
+    <ClInclude Include="ScopeGuard.h" />
+    <ClInclude Include="SDCardUtil.h" />
+    <ClInclude Include="SFMLHelper.h" />
+    <ClInclude Include="Semaphore.h" />
+    <ClInclude Include="SettingsHandler.h" />
+    <ClInclude Include="SPSCQueue.h" />
+    <ClInclude Include="StringUtil.h" />
+    <ClInclude Include="Swap.h" />
+    <ClInclude Include="SymbolDB.h" />
+    <ClInclude Include="Thread.h" />
+    <ClInclude Include="Timer.h" />
+    <ClInclude Include="TraversalClient.h" />
+    <ClInclude Include="TraversalProto.h" />
+    <ClInclude Include="UPnP.h" />
+    <ClInclude Include="VariantUtil.h" />
+    <ClInclude Include="Version.h" />
+    <ClInclude Include="WorkQueueThread.h" />
+    <ClInclude Include="x64ABI.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="x64Emitter.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="x64Reg.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="Crypto\AES.h" />
+    <ClInclude Include="Crypto\bn.h" />
+    <ClInclude Include="Crypto\ec.h" />
+    <ClInclude Include="Logging\ConsoleListener.h" />
+    <ClInclude Include="Logging\Log.h" />
+    <ClInclude Include="Logging\LogManager.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Analytics.cpp" />
+    <ClCompile Include="Arm64Emitter.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="ArmCPUDetect.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="CDUtils.cpp" />
+    <ClCompile Include="ColorUtil.cpp" />
+    <ClCompile Include="CommonFuncs.cpp" />
+    <ClCompile Include="CompatPatches.cpp" />
+    <ClCompile Include="Config\Config.cpp" />
+    <ClCompile Include="Config\ConfigInfo.cpp" />
+    <ClCompile Include="Config\Layer.cpp" />
+    <ClCompile Include="Debug\MemoryPatches.cpp" />
+    <ClCompile Include="Debug\Watches.cpp" />
+    <ClCompile Include="DynamicLibrary.cpp" />
+    <ClCompile Include="ENetUtil.cpp" />
+    <ClCompile Include="File.cpp" />
+    <ClCompile Include="FileSearch.cpp" />
+    <ClCompile Include="FileUtil.cpp" />
+    <ClCompile Include="FloatUtils.cpp" />
+    <ClCompile Include="GekkoDisassembler.cpp" />
+    <ClCompile Include="GenericFPURoundMode.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'=='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="GL\GLExtensions\GLExtensions.cpp" />
+    <ClCompile Include="GL\GLContext.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'=='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="GL\GLInterface\WGL.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'=='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="GL\GLUtil.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'=='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="Hash.cpp" />
+    <ClCompile Include="HttpRequest.cpp" />
+    <ClCompile Include="Image.cpp" />
+    <ClCompile Include="IniFile.cpp" />
+    <ClCompile Include="JitRegister.cpp" />
+    <ClCompile Include="LdrWatcher.cpp" />
+    <ClCompile Include="Logging\ConsoleListenerWin.cpp" />
+    <ClCompile Include="MathUtil.cpp" />
+    <ClCompile Include="Matrix.cpp" />
+    <ClCompile Include="MD5.cpp" />
+    <ClCompile Include="MemArena.cpp" />
+    <ClCompile Include="MemoryUtil.cpp" />
+    <ClCompile Include="MsgHandler.cpp" />
+    <ClCompile Include="NandPaths.cpp" />
+    <ClCompile Include="Network.cpp" />
+    <ClCompile Include="PcapFile.cpp" />
+    <ClCompile Include="Profiler.cpp" />
+    <ClCompile Include="QoSSession.cpp" />
+    <ClCompile Include="Random.cpp" />
+    <ClCompile Include="SDCardUtil.cpp" />
+    <ClCompile Include="SFMLHelper.cpp" />
+    <ClCompile Include="SettingsHandler.cpp" />
+    <ClCompile Include="StringUtil.cpp" />
+    <ClCompile Include="SymbolDB.cpp" />
+    <ClCompile Include="Thread.cpp" />
+    <ClCompile Include="Timer.cpp" />
+    <ClCompile Include="TraversalClient.cpp" />
+    <ClCompile Include="UPnP.cpp" />
+    <ClCompile Include="Version.cpp" />
+    <ClCompile Include="x64ABI.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="x64CPUDetect.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="x64Emitter.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="x64FPURoundMode.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="Crypto\AES.cpp" />
+    <ClCompile Include="Crypto\bn.cpp" />
+    <ClCompile Include="Crypto\ec.cpp" />
+    <ClCompile Include="Logging\LogManager.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(ExternalsDir)curl\curl.vcxproj">
+      <Project>{bb00605c-125f-4a21-b33b-7bf418322dcb}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)enet\enet.vcxproj">
+      <Project>{cbc76802-c128-4b17-bf6c-23b08c313e5e}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)libpng\png\png.vcxproj">
+      <Project>{4c9f135b-a85e-430c-bad4-4c67ef5fc12c}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)mbedtls\mbedTLS.vcxproj">
+      <Project>{bdb6578b-0691-4e80-a46c-df21639fd3b8}</Project>
+    </ProjectReference>
+    <ProjectReference Include="SCMRevGen.vcxproj">
+      <Project>{41279555-f94f-4ebc-99de-af863c10c5c4}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="BitField.natvis" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Core/Common/SCMRevGen.vcxproj
+++ b/Source/Core/Common/SCMRevGen.vcxproj
@@ -55,7 +55,16 @@
       <Command>"$(CScript)" /nologo /E:JScript "make_scmrev.h.js"</Command>
     </PreBuildEvent>
     <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp20</LanguageStandard>
+    </ClCompile>
+    <ClCompile>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpp20</LanguageStandard>
+    </ClCompile>
+    <ClCompile>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpp20</LanguageStandard>
+    </ClCompile>
+    <ClCompile>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/Core/Common/SCMRevGen.vcxproj
+++ b/Source/Core/Common/SCMRevGen.vcxproj
@@ -55,16 +55,16 @@
       <Command>"$(CScript)" /nologo /E:JScript "make_scmrev.h.js"</Command>
     </PreBuildEvent>
     <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpplatest</LanguageStandard>
     </ClCompile>
     <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpplatest</LanguageStandard>
     </ClCompile>
     <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpplatest</LanguageStandard>
     </ClCompile>
     <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpplatest</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -1,0 +1,773 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\VSProps\Base.Macros.props" />
+  <Import Project="$(VSPropsDir)Base.Targets.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{E54CF649-140E-4255-81A5-30A673C1FB36}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VSPropsDir)Configuration.StaticLibrary.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VSPropsDir)Base.props" />
+    <Import Project="$(VSPropsDir)PCHUse.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="ActionReplay.cpp" />
+    <ClCompile Include="Analytics.cpp" />
+    <ClCompile Include="ARDecrypt.cpp" />
+    <ClCompile Include="BootManager.cpp" />
+    <ClCompile Include="Boot\Boot.cpp" />
+    <ClCompile Include="Boot\Boot_BS2Emu.cpp" />
+    <ClCompile Include="Boot\Boot_WiiWAD.cpp" />
+    <ClCompile Include="Boot\DolReader.cpp" />
+    <ClCompile Include="Boot\ElfReader.cpp" />
+    <ClCompile Include="Config\GraphicsSettings.cpp" />
+    <ClCompile Include="Config\MainSettings.cpp" />
+    <ClCompile Include="Config\NetplaySettings.cpp" />
+    <ClCompile Include="Config\UISettings.cpp" />
+    <ClCompile Include="Config\SYSCONFSettings.cpp" />
+    <ClCompile Include="ConfigLoaders\BaseConfigLoader.cpp" />
+    <ClCompile Include="ConfigLoaders\GameConfigLoader.cpp" />
+    <ClCompile Include="ConfigLoaders\IsSettingSaveable.cpp" />
+    <ClCompile Include="ConfigLoaders\MovieConfigLoader.cpp" />
+    <ClCompile Include="ConfigLoaders\NetPlayConfigLoader.cpp" />
+    <ClCompile Include="ConfigManager.cpp" />
+    <ClCompile Include="Core.cpp" />
+    <ClCompile Include="CoreTiming.cpp" />
+    <ClCompile Include="Debugger\Debugger_SymbolMap.cpp" />
+    <ClCompile Include="Debugger\Dump.cpp" />
+    <ClCompile Include="Debugger\OSThread.cpp" />
+    <ClCompile Include="Debugger\PPCDebugInterface.cpp" />
+    <ClCompile Include="Debugger\RSO.cpp" />
+    <ClCompile Include="DSPEmulator.cpp" />
+    <ClCompile Include="DSP\DSPAccelerator.cpp" />
+    <ClCompile Include="DSP\DSPAnalyzer.cpp" />
+    <ClCompile Include="DSP\DSPAssembler.cpp" />
+    <ClCompile Include="DSP\DSPCaptureLogger.cpp" />
+    <ClCompile Include="DSP\DSPCodeUtil.cpp" />
+    <ClCompile Include="DSP\DSPCore.cpp" />
+    <ClCompile Include="DSP\DSPDisassembler.cpp" />
+    <ClCompile Include="DSP\DSPHWInterface.cpp" />
+    <ClCompile Include="DSP\DSPMemoryMap.cpp" />
+    <ClCompile Include="DSP\DSPStacks.cpp" />
+    <ClCompile Include="DSP\DSPTables.cpp" />
+    <ClCompile Include="DSP\Interpreter\DSPIntArithmetic.cpp" />
+    <ClCompile Include="DSP\Interpreter\DSPIntBranch.cpp" />
+    <ClCompile Include="DSP\Interpreter\DSPIntCCUtil.cpp" />
+    <ClCompile Include="DSP\Interpreter\DSPInterpreter.cpp" />
+    <ClCompile Include="DSP\Interpreter\DSPIntExtOps.cpp" />
+    <ClCompile Include="DSP\Interpreter\DSPIntLoadStore.cpp" />
+    <ClCompile Include="DSP\Interpreter\DSPIntMisc.cpp" />
+    <ClCompile Include="DSP\Interpreter\DSPIntMultiplier.cpp" />
+    <ClCompile Include="DSP\Interpreter\DSPIntTables.cpp" />
+    <ClCompile Include="DSP\Jit\DSPEmitterBase.cpp" />
+    <ClCompile Include="DSP\Jit\x64\DSPEmitter.cpp" />
+    <ClCompile Include="DSP\Jit\x64\DSPJitArithmetic.cpp" />
+    <ClCompile Include="DSP\Jit\x64\DSPJitBranch.cpp" />
+    <ClCompile Include="DSP\Jit\x64\DSPJitCCUtil.cpp" />
+    <ClCompile Include="DSP\Jit\x64\DSPJitExtOps.cpp" />
+    <ClCompile Include="DSP\Jit\x64\DSPJitLoadStore.cpp" />
+    <ClCompile Include="DSP\Jit\x64\DSPJitMisc.cpp" />
+    <ClCompile Include="DSP\Jit\x64\DSPJitMultiplier.cpp" />
+    <ClCompile Include="DSP\Jit\x64\DSPJitRegCache.cpp" />
+    <ClCompile Include="DSP\Jit\x64\DSPJitTables.cpp" />
+    <ClCompile Include="DSP\Jit\x64\DSPJitUtil.cpp" />
+    <ClCompile Include="DSP\LabelMap.cpp" />
+    <ClCompile Include="FifoPlayer\FifoAnalyzer.cpp" />
+    <ClCompile Include="FifoPlayer\FifoDataFile.cpp" />
+    <ClCompile Include="FifoPlayer\FifoPlaybackAnalyzer.cpp" />
+    <ClCompile Include="FifoPlayer\FifoPlayer.cpp" />
+    <ClCompile Include="FifoPlayer\FifoRecordAnalyzer.cpp" />
+    <ClCompile Include="FifoPlayer\FifoRecorder.cpp" />
+    <ClCompile Include="GeckoCode.cpp" />
+    <ClCompile Include="GeckoCodeConfig.cpp" />
+    <ClCompile Include="HLE\HLE.cpp" />
+    <ClCompile Include="HLE\HLE_Misc.cpp" />
+    <ClCompile Include="HLE\HLE_OS.cpp" />
+    <ClCompile Include="HLE\HLE_VarArgs.cpp" />
+    <ClCompile Include="HotkeyManager.cpp" />
+    <ClCompile Include="HW\AddressSpace.cpp" />
+    <ClCompile Include="HW\AudioInterface.cpp" />
+    <ClCompile Include="HW\CPU.cpp" />
+    <ClCompile Include="HW\DSP.cpp" />
+    <ClCompile Include="HW\DSPHLE\DSPHLE.cpp" />
+    <ClCompile Include="HW\DSPHLE\MailHandler.cpp" />
+    <ClCompile Include="HW\DSPHLE\UCodes\UCodes.cpp" />
+    <ClCompile Include="HW\DSPHLE\UCodes\AX.cpp" />
+    <ClCompile Include="HW\DSPHLE\UCodes\AXWii.cpp" />
+    <ClCompile Include="HW\DSPHLE\UCodes\CARD.cpp" />
+    <ClCompile Include="HW\DSPHLE\UCodes\GBA.cpp" />
+    <ClCompile Include="HW\DSPHLE\UCodes\INIT.cpp" />
+    <ClCompile Include="HW\DSPHLE\UCodes\ROM.cpp" />
+    <ClCompile Include="HW\DSPHLE\UCodes\Zelda.cpp" />
+    <ClCompile Include="HW\DSPLLE\DSPDebugInterface.cpp" />
+    <ClCompile Include="HW\DSPLLE\DSPHost.cpp" />
+    <ClCompile Include="HW\DSPLLE\DSPLLE.cpp" />
+    <ClCompile Include="HW\DSPLLE\DSPLLEGlobals.cpp" />
+    <ClCompile Include="HW\DSPLLE\DSPSymbols.cpp" />
+    <ClCompile Include="HW\DVD\DVDInterface.cpp" />
+    <ClCompile Include="HW\DVD\DVDMath.cpp" />
+    <ClCompile Include="HW\DVD\DVDThread.cpp" />
+    <ClCompile Include="HW\DVD\FileMonitor.cpp" />
+    <ClCompile Include="HW\EXI\BBA\TAP_Win32.cpp" />
+    <ClCompile Include="HW\EXI\BBA\XLINK_KAI_BBA.cpp" />
+    <ClCompile Include="HW\EXI\EXI.cpp" />
+    <ClCompile Include="HW\EXI\EXI_Channel.cpp" />
+    <ClCompile Include="HW\EXI\EXI_Device.cpp" />
+    <ClCompile Include="HW\EXI\EXI_DeviceAD16.cpp" />
+    <ClCompile Include="HW\EXI\EXI_DeviceAGP.cpp" />
+    <ClCompile Include="HW\EXI\EXI_DeviceDummy.cpp" />
+    <ClCompile Include="HW\EXI\EXI_DeviceEthernet.cpp" />
+    <ClCompile Include="HW\EXI\EXI_DeviceGecko.cpp" />
+    <ClCompile Include="HW\EXI\EXI_DeviceIPL.cpp" />
+    <ClCompile Include="HW\EXI\EXI_DeviceMemoryCard.cpp" />
+    <ClCompile Include="HW\EXI\EXI_DeviceMic.cpp" />
+    <ClCompile Include="HW\GCKeyboard.cpp" />
+    <ClCompile Include="HW\GCKeyboardEmu.cpp" />
+    <ClCompile Include="HW\GCMemcard\GCIFile.cpp" />
+    <ClCompile Include="HW\GCMemcard\GCMemcard.cpp" />
+    <ClCompile Include="HW\GCMemcard\GCMemcardDirectory.cpp" />
+    <ClCompile Include="HW\GCMemcard\GCMemcardRaw.cpp" />
+    <ClCompile Include="HW\GCMemcard\GCMemcardUtils.cpp" />
+    <ClCompile Include="HW\GCPad.cpp" />
+    <ClCompile Include="HW\GCPadEmu.cpp" />
+    <ClCompile Include="HW\GPFifo.cpp" />
+    <ClCompile Include="HW\HW.cpp" />
+    <ClCompile Include="HW\Memmap.cpp" />
+    <ClCompile Include="HW\MemoryInterface.cpp" />
+    <ClCompile Include="HW\MMIO.cpp" />
+    <ClCompile Include="HW\ProcessorInterface.cpp" />
+    <ClCompile Include="HW\SI\SI.cpp" />
+    <ClCompile Include="HW\SI\SI_Device.cpp" />
+    <ClCompile Include="HW\SI\SI_DeviceDanceMat.cpp" />
+    <ClCompile Include="HW\SI\SI_DeviceGBA.cpp" />
+    <ClCompile Include="HW\SI\SI_DeviceGCAdapter.cpp" />
+    <ClCompile Include="HW\SI\SI_DeviceGCController.cpp" />
+    <ClCompile Include="HW\SI\SI_DeviceGCSteeringWheel.cpp" />
+    <ClCompile Include="HW\SI\SI_DeviceKeyboard.cpp" />
+    <ClCompile Include="HW\SI\SI_DeviceNull.cpp" />
+    <ClCompile Include="HW\Sram.cpp" />
+    <ClCompile Include="HW\StreamADPCM.cpp" />
+    <ClCompile Include="HW\SystemTimers.cpp" />
+    <ClCompile Include="HW\VideoInterface.cpp" />
+    <ClCompile Include="HW\Wiimote.cpp" />
+    <ClCompile Include="HW\WiimoteCommon\DataReport.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\Camera.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\Dynamics.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\EmuSubroutines.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\Encryption.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\ExtensionPort.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\Extension\Classic.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\Extension\DrawsomeTablet.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\Extension\Drums.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\Extension\Extension.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\Extension\Guitar.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\Extension\Nunchuk.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\Extension\TaTaCon.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\Extension\Turntable.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\Extension\UDrawTablet.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\I2CBus.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\MotionPlus.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\Speaker.cpp" />
+    <ClCompile Include="HW\WiimoteEmu\WiimoteEmu.cpp" />
+    <ClCompile Include="HW\WiimoteReal\IOWin.cpp" />
+    <ClCompile Include="HW\WiimoteReal\WiimoteReal.cpp" />
+    <ClCompile Include="HW\WII_IPC.cpp" />
+    <ClCompile Include="HW\WiiSave.cpp" />
+    <ClCompile Include="IOS\Device.cpp" />
+    <ClCompile Include="IOS\DeviceStub.cpp" />
+    <ClCompile Include="IOS\DolphinDevice.cpp" />
+    <ClCompile Include="IOS\IOS.cpp" />
+    <ClCompile Include="IOS\IOSC.cpp" />
+    <ClCompile Include="IOS\MIOS.cpp" />
+    <ClCompile Include="IOS\VersionInfo.cpp" />
+    <ClCompile Include="IOS\DI\DI.cpp" />
+    <ClCompile Include="IOS\ES\ES.cpp" />
+    <ClCompile Include="IOS\ES\Formats.cpp" />
+    <ClCompile Include="IOS\ES\Identity.cpp" />
+    <ClCompile Include="IOS\ES\NandUtils.cpp" />
+    <ClCompile Include="IOS\ES\TitleContents.cpp" />
+    <ClCompile Include="IOS\ES\TitleInformation.cpp" />
+    <ClCompile Include="IOS\ES\TitleManagement.cpp" />
+    <ClCompile Include="IOS\ES\Views.cpp" />
+    <ClCompile Include="IOS\FS\FileSystem.cpp" />
+    <ClCompile Include="IOS\FS\FileSystemProxy.cpp" />
+    <ClCompile Include="IOS\FS\HostBackend\FS.cpp" />
+    <ClCompile Include="IOS\FS\HostBackend\File.cpp" />
+    <ClCompile Include="IOS\Network\ICMPLin.cpp" />
+    <ClCompile Include="IOS\Network\MACUtils.cpp" />
+    <ClCompile Include="IOS\Network\Socket.cpp" />
+    <ClCompile Include="IOS\Network\SSL.cpp" />
+    <ClCompile Include="IOS\Network\IP\Top.cpp" />
+    <ClCompile Include="IOS\Network\KD\NetKDRequest.cpp" />
+    <ClCompile Include="IOS\Network\KD\NetKDTime.cpp" />
+    <ClCompile Include="IOS\Network\KD\NWC24Config.cpp" />
+    <ClCompile Include="IOS\Network\NCD\WiiNetConfig.cpp" />
+    <ClCompile Include="IOS\Network\NCD\Manage.cpp" />
+    <ClCompile Include="IOS\Network\WD\Command.cpp" />
+    <ClCompile Include="IOS\SDIO\SDIOSlot0.cpp" />
+    <ClCompile Include="IOS\STM\STM.cpp" />
+    <ClCompile Include="IOS\USB\Common.cpp" />
+    <ClCompile Include="IOS\USB\LibusbDevice.cpp" />
+    <ClCompile Include="LibusbUtils.cpp" />
+    <ClCompile Include="IOS\USB\Host.cpp" />
+    <ClCompile Include="IOS\USB\OH0\OH0.cpp" />
+    <ClCompile Include="IOS\USB\OH0\OH0Device.cpp" />
+    <ClCompile Include="IOS\USB\USB_HID\HIDv4.cpp" />
+    <ClCompile Include="IOS\USB\USB_HID\HIDv5.cpp" />
+    <ClCompile Include="IOS\USB\USB_VEN\VEN.cpp" />
+    <ClCompile Include="IOS\USB\USBV0.cpp" />
+    <ClCompile Include="IOS\USB\USBV4.cpp" />
+    <ClCompile Include="IOS\USB\USBV5.cpp" />
+    <ClCompile Include="IOS\USB\USB_KBD.cpp" />
+    <ClCompile Include="IOS\USB\Bluetooth\BTBase.cpp" />
+    <ClCompile Include="IOS\USB\Bluetooth\BTEmu.cpp" />
+    <ClCompile Include="IOS\USB\Bluetooth\BTStub.cpp" />
+    <ClCompile Include="IOS\USB\Bluetooth\BTReal.cpp" />
+    <ClCompile Include="IOS\USB\Bluetooth\WiimoteDevice.cpp" />
+    <ClCompile Include="IOS\USB\Bluetooth\WiimoteHIDAttr.cpp" />
+    <ClCompile Include="IOS\WFS\WFSI.cpp" />
+    <ClCompile Include="IOS\WFS\WFSSRV.cpp" />
+    <ClCompile Include="MemTools.cpp" />
+    <ClCompile Include="Movie.cpp" />
+    <ClCompile Include="NetPlayClient.cpp" />
+    <ClCompile Include="NetPlayServer.cpp" />
+    <ClCompile Include="PatchEngine.cpp" />
+    <ClCompile Include="PowerPC\BreakPoints.cpp" />
+    <ClCompile Include="PowerPC\CachedInterpreter\CachedInterpreter.cpp" />
+    <ClCompile Include="PowerPC\CachedInterpreter\InterpreterBlockCache.cpp" />
+    <ClCompile Include="PowerPC\ConditionRegister.cpp" />
+    <ClCompile Include="PowerPC\Interpreter\Interpreter.cpp" />
+    <ClCompile Include="PowerPC\Interpreter\Interpreter_Branch.cpp" />
+    <ClCompile Include="PowerPC\Interpreter\Interpreter_FloatingPoint.cpp" />
+    <ClCompile Include="PowerPC\Interpreter\Interpreter_Integer.cpp" />
+    <ClCompile Include="PowerPC\Interpreter\Interpreter_LoadStore.cpp" />
+    <ClCompile Include="PowerPC\Interpreter\Interpreter_LoadStorePaired.cpp" />
+    <ClCompile Include="PowerPC\Interpreter\Interpreter_Paired.cpp" />
+    <ClCompile Include="PowerPC\Interpreter\Interpreter_SystemRegisters.cpp" />
+    <ClCompile Include="PowerPC\Interpreter\Interpreter_Tables.cpp" />
+    <ClCompile Include="PowerPC\Jit64\Jit.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64\Jit64_Tables.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64\Jit_Branch.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64\Jit_FloatingPoint.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64\Jit_Integer.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64\Jit_LoadStore.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64\Jit_LoadStoreFloating.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64\Jit_LoadStorePaired.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64\Jit_Paired.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64\Jit_SystemRegisters.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64\JitAsm.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64\RegCache\FPURegCache.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64\RegCache\GPRRegCache.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64\RegCache\JitRegCache.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64Common\BlockCache.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64Common\ConstantPool.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64Common\EmuCodeBlock.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64Common\FarCodeCache.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64Common\Jit64AsmCommon.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\Jit64Common\TrampolineCache.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\JitArm64\Jit.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\JitArm64\JitArm64Cache.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\JitArm64\JitArm64_BackPatch.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\JitArm64\JitArm64_Branch.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\JitArm64\JitArm64_FloatingPoint.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\JitArm64\JitArm64_Integer.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\JitArm64\JitArm64_LoadStore.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\JitArm64\JitArm64_LoadStoreFloating.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\JitArm64\JitArm64_LoadStorePaired.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\JitArm64\JitArm64_Paired.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\JitArm64\JitArm64_RegCache.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\JitArm64\JitArm64_SystemRegisters.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\JitArm64\JitArm64_Tables.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\JitArm64\JitAsm.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\JitArm64\Jit_Util.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="PowerPC\JitCommon\JitAsmCommon.cpp" />
+    <ClCompile Include="PowerPC\JitCommon\JitBase.cpp" />
+    <ClCompile Include="PowerPC\JitCommon\JitCache.cpp" />
+    <ClCompile Include="PowerPC\JitInterface.cpp" />
+    <ClCompile Include="PowerPC\MMU.cpp" />
+    <ClCompile Include="PowerPC\PowerPC.cpp" />
+    <ClCompile Include="PowerPC\PPCAnalyst.cpp" />
+    <ClCompile Include="PowerPC\PPCCache.cpp" />
+    <ClCompile Include="PowerPC\PPCSymbolDB.cpp" />
+    <ClCompile Include="PowerPC\PPCTables.cpp" />
+    <ClCompile Include="PowerPC\SignatureDB\CSVSignatureDB.cpp" />
+    <ClCompile Include="PowerPC\SignatureDB\DSYSignatureDB.cpp" />
+    <ClCompile Include="PowerPC\SignatureDB\MEGASignatureDB.cpp" />
+    <ClCompile Include="PowerPC\SignatureDB\SignatureDB.cpp" />
+    <ClCompile Include="PrimeHack\HackConfig.cpp" />
+    <ClCompile Include="PrimeHack\HackManager.cpp" />
+    <ClCompile Include="PrimeHack\Mods\AutoEFB.cpp" />
+    <ClCompile Include="PrimeHack\Mods\CutBeamFxMP1.cpp" />
+    <ClCompile Include="PrimeHack\Mods\FpsControls.cpp" />
+    <ClCompile Include="PrimeHack\Mods\ContextSensitiveControls.cpp" />
+    <ClCompile Include="PrimeHack\Mods\Noclip.cpp" />
+    <ClCompile Include="PrimeHack\Mods\SpringballButton.cpp" />
+    <ClCompile Include="PrimeHack\Mods\ViewModifier.cpp" />
+    <ClCompile Include="PrimeHack\PrimeUtils.cpp" />
+    <ClCompile Include="PrimeHack\Transform.cpp" />
+    <ClCompile Include="State.cpp" />
+    <ClCompile Include="SysConf.cpp" />
+    <ClCompile Include="TitleDatabase.cpp" />
+    <ClCompile Include="WiiRoot.cpp" />
+    <ClCompile Include="WiiUtils.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="ActionReplay.h" />
+    <ClInclude Include="Analytics.h" />
+    <ClInclude Include="ARDecrypt.h" />
+    <ClInclude Include="BootManager.h" />
+    <ClInclude Include="Boot\Boot.h" />
+    <ClInclude Include="Boot\DolReader.h" />
+    <ClInclude Include="Boot\ElfReader.h" />
+    <ClInclude Include="Boot\ElfTypes.h" />
+    <ClInclude Include="Config\GraphicsSettings.h" />
+    <ClInclude Include="Config\MainSettings.h" />
+    <ClInclude Include="Config\NetplaySettings.h" />
+    <ClInclude Include="Config\SYSCONFSettings.h" />
+    <ClInclude Include="ConfigLoaders\BaseConfigLoader.h" />
+    <ClInclude Include="ConfigLoaders\GameConfigLoader.h" />
+    <ClInclude Include="ConfigLoaders\IsSettingSaveable.h" />
+    <ClInclude Include="ConfigLoaders\MovieConfigLoader.h" />
+    <ClInclude Include="ConfigLoaders\NetPlayConfigLoader.h" />
+    <ClInclude Include="ConfigManager.h" />
+    <ClInclude Include="Config\UISettings.h" />
+    <ClInclude Include="Core.h" />
+    <ClInclude Include="CoreTiming.h" />
+    <ClInclude Include="Debugger\Debugger_SymbolMap.h" />
+    <ClInclude Include="Debugger\Dump.h" />
+    <ClInclude Include="Debugger\GCELF.h" />
+    <ClInclude Include="Debugger\OSThread.h" />
+    <ClInclude Include="Debugger\PPCDebugInterface.h" />
+    <ClInclude Include="Debugger\RSO.h" />
+    <ClInclude Include="DSPEmulator.h" />
+    <ClInclude Include="DSP\DSPAccelerator.h" />
+    <ClInclude Include="DSP\DSPAnalyzer.h" />
+    <ClInclude Include="DSP\DSPAssembler.h" />
+    <ClInclude Include="DSP\DSPBreakpoints.h" />
+    <ClInclude Include="DSP\DSPCaptureLogger.h" />
+    <ClInclude Include="DSP\DSPCodeUtil.h" />
+    <ClInclude Include="DSP\DSPCommon.h" />
+    <ClInclude Include="DSP\DSPCore.h" />
+    <ClInclude Include="DSP\DSPDisassembler.h" />
+    <ClInclude Include="DSP\DSPHost.h" />
+    <ClInclude Include="DSP\DSPHWInterface.h" />
+    <ClInclude Include="DSP\DSPMemoryMap.h" />
+    <ClInclude Include="DSP\DSPStacks.h" />
+    <ClInclude Include="DSP\DSPTables.h" />
+    <ClInclude Include="DSP\Interpreter\DSPIntCCUtil.h" />
+    <ClInclude Include="DSP\Interpreter\DSPInterpreter.h" />
+    <ClInclude Include="DSP\Interpreter\DSPIntExtOps.h" />
+    <ClInclude Include="DSP\Interpreter\DSPIntTables.h" />
+    <ClInclude Include="DSP\Interpreter\DSPIntUtil.h" />
+    <ClInclude Include="DSP\Jit\DSPEmitterBase.h" />
+    <ClInclude Include="DSP\Jit\x64\DSPEmitter.h" />
+    <ClInclude Include="DSP\Jit\x64\DSPJitRegCache.h" />
+    <ClInclude Include="DSP\Jit\x64\DSPJitTables.h" />
+    <ClInclude Include="DSP\LabelMap.h" />
+    <ClInclude Include="FifoPlayer\FifoAnalyzer.h" />
+    <ClInclude Include="FifoPlayer\FifoDataFile.h" />
+    <ClInclude Include="FifoPlayer\FifoPlaybackAnalyzer.h" />
+    <ClInclude Include="FifoPlayer\FifoPlayer.h" />
+    <ClInclude Include="FifoPlayer\FifoRecordAnalyzer.h" />
+    <ClInclude Include="FifoPlayer\FifoRecorder.h" />
+    <ClInclude Include="GeckoCode.h" />
+    <ClInclude Include="GeckoCodeConfig.h" />
+    <ClInclude Include="HLE\HLE.h" />
+    <ClInclude Include="HLE\HLE_Misc.h" />
+    <ClInclude Include="HLE\HLE_OS.h" />
+    <ClInclude Include="HLE\HLE_VarArgs.h" />
+    <ClInclude Include="Host.h" />
+    <ClInclude Include="HotkeyManager.h" />
+    <ClInclude Include="HW\AddressSpace.h" />
+    <ClInclude Include="HW\AudioInterface.h" />
+    <ClInclude Include="HW\CPU.h" />
+    <ClInclude Include="HW\DSP.h" />
+    <ClInclude Include="HW\DSPHLE\DSPHLE.h" />
+    <ClInclude Include="HW\DSPHLE\MailHandler.h" />
+    <ClInclude Include="HW\DSPHLE\UCodes\UCodes.h" />
+    <ClInclude Include="HW\DSPHLE\UCodes\AX.h" />
+    <ClInclude Include="HW\DSPHLE\UCodes\AXStructs.h" />
+    <ClInclude Include="HW\DSPHLE\UCodes\AXWii.h" />
+    <ClInclude Include="HW\DSPHLE\UCodes\AXVoice.h" />
+    <ClInclude Include="HW\DSPHLE\UCodes\CARD.h" />
+    <ClInclude Include="HW\DSPHLE\UCodes\GBA.h" />
+    <ClInclude Include="HW\DSPHLE\UCodes\INIT.h" />
+    <ClInclude Include="HW\DSPHLE\UCodes\ROM.h" />
+    <ClInclude Include="HW\DSPHLE\UCodes\Zelda.h" />
+    <ClInclude Include="HW\DSPLLE\DSPDebugInterface.h" />
+    <ClInclude Include="HW\DSPLLE\DSPLLE.h" />
+    <ClInclude Include="HW\DSPLLE\DSPLLEGlobals.h" />
+    <ClInclude Include="HW\DSPLLE\DSPSymbols.h" />
+    <ClInclude Include="HW\DVD\DVDInterface.h" />
+    <ClInclude Include="HW\DVD\DVDMath.h" />
+    <ClInclude Include="HW\DVD\DVDThread.h" />
+    <ClInclude Include="HW\DVD\FileMonitor.h" />
+    <ClInclude Include="HW\EXI\BBA\TAP_Win32.h" />
+    <ClInclude Include="HW\EXI\EXI.h" />
+    <ClInclude Include="HW\EXI\EXI_Channel.h" />
+    <ClInclude Include="HW\EXI\EXI_Device.h" />
+    <ClInclude Include="HW\EXI\EXI_DeviceAD16.h" />
+    <ClInclude Include="HW\EXI\EXI_DeviceAGP.h" />
+    <ClInclude Include="HW\EXI\EXI_DeviceDummy.h" />
+    <ClInclude Include="HW\EXI\EXI_DeviceEthernet.h" />
+    <ClInclude Include="HW\EXI\EXI_DeviceGecko.h" />
+    <ClInclude Include="HW\EXI\EXI_DeviceIPL.h" />
+    <ClInclude Include="HW\EXI\EXI_DeviceMemoryCard.h" />
+    <ClInclude Include="HW\EXI\EXI_DeviceMic.h" />
+    <ClInclude Include="HW\GCKeyboard.h" />
+    <ClInclude Include="HW\GCKeyboardEmu.h" />
+    <ClInclude Include="HW\GCMemcard\GCIFile.h" />
+    <ClInclude Include="HW\GCMemcard\GCMemcard.h" />
+    <ClInclude Include="HW\GCMemcard\GCMemcardBase.h" />
+    <ClInclude Include="HW\GCMemcard\GCMemcardDirectory.h" />
+    <ClInclude Include="HW\GCMemcard\GCMemcardRaw.h" />
+    <ClInclude Include="HW\GCMemcard\GCMemcardUtils.h" />
+    <ClInclude Include="HW\GCPad.h" />
+    <ClInclude Include="HW\GCPadEmu.h" />
+    <ClInclude Include="HW\GPFifo.h" />
+    <ClInclude Include="HW\HW.h" />
+    <ClInclude Include="HW\Memmap.h" />
+    <ClInclude Include="HW\MemoryInterface.h" />
+    <ClInclude Include="HW\MMIO.h" />
+    <ClInclude Include="HW\MMIOHandlers.h" />
+    <ClInclude Include="HW\ProcessorInterface.h" />
+    <ClInclude Include="HW\SI\SI.h" />
+    <ClInclude Include="HW\SI\SI_Device.h" />
+    <ClInclude Include="HW\SI\SI_DeviceDanceMat.h" />
+    <ClInclude Include="HW\SI\SI_DeviceGBA.h" />
+    <ClInclude Include="HW\SI\SI_DeviceGCAdapter.h" />
+    <ClInclude Include="HW\SI\SI_DeviceGCController.h" />
+    <ClInclude Include="HW\SI\SI_DeviceGCSteeringWheel.h" />
+    <ClInclude Include="HW\SI\SI_DeviceKeyboard.h" />
+    <ClInclude Include="HW\SI\SI_DeviceNull.h" />
+    <ClInclude Include="HW\Sram.h" />
+    <ClInclude Include="HW\StreamADPCM.h" />
+    <ClInclude Include="HW\SystemTimers.h" />
+    <ClInclude Include="HW\VideoInterface.h" />
+    <ClInclude Include="HW\Wiimote.h" />
+    <ClInclude Include="HW\WiimoteCommon\DataReport.h" />
+    <ClInclude Include="HW\WiimoteCommon\WiimoteConstants.h" />
+    <ClInclude Include="HW\WiimoteCommon\WiimoteHid.h" />
+    <ClInclude Include="HW\WiimoteCommon\WiimoteReport.h" />
+    <ClInclude Include="HW\WiimoteEmu\Camera.h" />
+    <ClInclude Include="HW\WiimoteEmu\Dynamics.h" />
+    <ClInclude Include="HW\WiimoteEmu\Encryption.h" />
+    <ClInclude Include="HW\WiimoteEmu\ExtensionPort.h" />
+    <ClInclude Include="HW\WiimoteEmu\Extension\Classic.h" />
+    <ClInclude Include="HW\WiimoteEmu\Extension\DrawsomeTablet.h" />
+    <ClInclude Include="HW\WiimoteEmu\Extension\Drums.h" />
+    <ClInclude Include="HW\WiimoteEmu\Extension\Extension.h" />
+    <ClInclude Include="HW\WiimoteEmu\Extension\Guitar.h" />
+    <ClInclude Include="HW\WiimoteEmu\Extension\Nunchuk.h" />
+    <ClInclude Include="HW\WiimoteEmu\Extension\TaTaCon.h" />
+    <ClInclude Include="HW\WiimoteEmu\Extension\Turntable.h" />
+    <ClInclude Include="HW\WiimoteEmu\Extension\UDrawTablet.h" />
+    <ClInclude Include="HW\WiimoteEmu\I2CBus.h" />
+    <ClInclude Include="HW\WiimoteEmu\MotionPlus.h" />
+    <ClInclude Include="HW\WiimoteEmu\Speaker.h" />
+    <ClInclude Include="HW\WiimoteEmu\WiimoteEmu.h" />
+    <ClInclude Include="HW\WiimoteReal\WiimoteReal.h" />
+    <ClInclude Include="HW\WiimoteReal\WiimoteRealBase.h" />
+    <ClInclude Include="HW\WiiSave.h" />
+    <ClInclude Include="HW\WiiSaveStructs.h" />
+    <ClInclude Include="HW\WII_IPC.h" />
+    <ClInclude Include="IOS\Device.h" />
+    <ClInclude Include="IOS\DeviceStub.h" />
+    <ClInclude Include="IOS\DolphinDevice.h" />
+    <ClInclude Include="IOS\IOS.h" />
+    <ClInclude Include="IOS\IOSC.h" />
+    <ClInclude Include="IOS\MIOS.h" />
+    <ClInclude Include="IOS\VersionInfo.h" />
+    <ClInclude Include="IOS\DI\DI.h" />
+    <ClInclude Include="IOS\ES\ES.h" />
+    <ClInclude Include="IOS\ES\Formats.h" />
+    <ClInclude Include="IOS\FS\FileSystem.h" />
+    <ClInclude Include="IOS\FS\FileSystemProxy.h" />
+    <ClInclude Include="IOS\FS\HostBackend\File.h" />
+    <ClInclude Include="IOS\FS\HostBackend\FS.h" />
+    <ClInclude Include="IOS\Network\ICMPLin.h" />
+    <ClInclude Include="IOS\Network\ICMP.h" />
+    <ClInclude Include="IOS\Network\MACUtils.h" />
+    <ClInclude Include="IOS\Network\Socket.h" />
+    <ClInclude Include="IOS\Network\SSL.h" />
+    <ClInclude Include="IOS\Network\IP\Top.h" />
+    <ClInclude Include="IOS\Network\KD\NetKDRequest.h" />
+    <ClInclude Include="IOS\Network\KD\NetKDTime.h" />
+    <ClInclude Include="IOS\Network\KD\NWC24Config.h" />
+    <ClInclude Include="IOS\Network\NCD\WiiNetConfig.h" />
+    <ClInclude Include="IOS\Network\NCD\Manage.h" />
+    <ClInclude Include="IOS\Network\WD\Command.h" />
+    <ClInclude Include="IOS\SDIO\SDIOSlot0.h" />
+    <ClInclude Include="IOS\STM\STM.h" />
+    <ClInclude Include="IOS\USB\Common.h" />
+    <ClInclude Include="IOS\USB\LibusbDevice.h" />
+    <ClInclude Include="LibusbUtils.h" />
+    <ClInclude Include="IOS\USB\Host.h" />
+    <ClInclude Include="IOS\USB\OH0\OH0.h" />
+    <ClInclude Include="IOS\USB\OH0\OH0Device.h" />
+    <ClInclude Include="IOS\USB\USB_HID\HIDv4.h" />
+    <ClInclude Include="IOS\USB\USB_HID\HIDv5.h" />
+    <ClInclude Include="IOS\USB\USB_VEN\VEN.h" />
+    <ClInclude Include="IOS\USB\USBV0.h" />
+    <ClInclude Include="IOS\USB\USBV4.h" />
+    <ClInclude Include="IOS\USB\USBV5.h" />
+    <ClInclude Include="IOS\USB\USB_KBD.h" />
+    <ClInclude Include="IOS\USB\Bluetooth\BTBase.h" />
+    <ClInclude Include="IOS\USB\Bluetooth\BTEmu.h" />
+    <ClInclude Include="IOS\USB\Bluetooth\BTStub.h" />
+    <ClInclude Include="IOS\USB\Bluetooth\BTReal.h" />
+    <ClInclude Include="IOS\USB\Bluetooth\WiimoteDevice.h" />
+    <ClInclude Include="IOS\USB\Bluetooth\WiimoteHIDAttr.h" />
+    <ClInclude Include="IOS\USB\Bluetooth\hci.h" />
+    <ClInclude Include="IOS\USB\Bluetooth\l2cap.h" />
+    <ClInclude Include="IOS\WFS\WFSSRV.h" />
+    <ClInclude Include="IOS\WFS\WFSI.h" />
+    <ClInclude Include="MachineContext.h" />
+    <ClInclude Include="MemTools.h" />
+    <ClInclude Include="Movie.h" />
+    <ClInclude Include="NetPlayClient.h" />
+    <ClInclude Include="NetPlayProto.h" />
+    <ClInclude Include="NetPlayServer.h" />
+    <ClInclude Include="PatchEngine.h" />
+    <ClInclude Include="PowerPC\BreakPoints.h" />
+    <ClInclude Include="PowerPC\CPUCoreBase.h" />
+    <ClInclude Include="PowerPC\Gekko.h" />
+    <ClInclude Include="PowerPC\CachedInterpreter\CachedInterpreter.h" />
+    <ClInclude Include="PowerPC\CachedInterpreter\InterpreterBlockCache.h" />
+    <ClInclude Include="PowerPC\ConditionRegister.h" />
+    <ClInclude Include="PowerPC\Interpreter\ExceptionUtils.h" />
+    <ClInclude Include="PowerPC\Interpreter\Interpreter.h" />
+    <ClInclude Include="PowerPC\Interpreter\Interpreter_FPUtils.h" />
+    <ClInclude Include="PowerPC\Jit64Common\ConstantPool.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\Jit64\FPURegCache.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\Jit64\GPRRegCache.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\Jit64\Jit.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\Jit64\JitAsm.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\Jit64\JitRegCache.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\Jit64Common\BlockCache.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\Jit64Common\EmuCodeBlock.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\Jit64Common\FarCodeCache.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\Jit64Common\Jit64AsmCommon.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\Jit64Common\Jit64Constants.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\Jit64Common\Jit64PowerPCState.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\Jit64Common\TrampolineCache.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\Jit64Common\TrampolineInfo.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\JitArm64\Jit.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\JitArm64\JitArm64Cache.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\JitArm64\JitArm64_RegCache.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\JitArm64\Jit_Util.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\JitArmCommon\BackPatch.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="PowerPC\JitCommon\JitAsmCommon.h" />
+    <ClInclude Include="PowerPC\JitCommon\JitBase.h" />
+    <ClInclude Include="PowerPC\JitCommon\JitCache.h" />
+    <ClInclude Include="PowerPC\SignatureDB\CSVSignatureDB.h" />
+    <ClInclude Include="PowerPC\SignatureDB\DSYSignatureDB.h" />
+    <ClInclude Include="PowerPC\SignatureDB\MEGASignatureDB.h" />
+    <ClInclude Include="PowerPC\SignatureDB\SignatureDB.h" />
+    <ClInclude Include="PowerPC\JitInterface.h" />
+    <ClInclude Include="PowerPC\MMU.h" />
+    <ClInclude Include="PowerPC\PowerPC.h" />
+    <ClInclude Include="PowerPC\PPCAnalyst.h" />
+    <ClInclude Include="PowerPC\PPCCache.h" />
+    <ClInclude Include="PowerPC\PPCSymbolDB.h" />
+    <ClInclude Include="PowerPC\PPCTables.h" />
+    <ClInclude Include="PowerPC\Profiler.h" />
+    <ClInclude Include="PrimeHack\HackConfig.h" />
+    <ClInclude Include="PrimeHack\HackManager.h" />
+    <ClInclude Include="PrimeHack\Mods\AutoEFB.h" />
+    <ClInclude Include="PrimeHack\Mods\CutBeamFxMP1.h" />
+    <ClInclude Include="PrimeHack\Mods\DisableBloom.h" />
+    <ClInclude Include="PrimeHack\Mods\FpsControls.h" />
+    <ClInclude Include="PrimeHack\Mods\ContextSensitiveControls.h" />
+    <ClInclude Include="PrimeHack\Mods\Invulnerability.h" />
+    <ClInclude Include="PrimeHack\Mods\Noclip.h" />
+    <ClInclude Include="PrimeHack\Mods\RestoreDashing.h" />
+    <ClInclude Include="PrimeHack\Mods\SkipCutscene.h" />
+    <ClInclude Include="PrimeHack\Mods\SpringballButton.h" />
+    <ClInclude Include="PrimeHack\Mods\ViewModifier.h" />
+    <ClInclude Include="PrimeHack\PrimeMod.h" />
+    <ClInclude Include="PrimeHack\PrimeUtils.h" />
+    <ClInclude Include="PrimeHack\Transform.h" />
+    <ClInclude Include="State.h" />
+    <ClInclude Include="SyncIdentifier.h" />
+    <ClInclude Include="SysConf.h" />
+    <ClInclude Include="Titles.h" />
+    <ClInclude Include="TitleDatabase.h" />
+    <ClInclude Include="WiiRoot.h" />
+    <ClInclude Include="WiiUtils.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CoreDir)AudioCommon\AudioCommon.vcxproj">
+      <Project>{54aa7840-5beb-4a0c-9452-74ba4cc7fd44}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(CoreDir)Common\Common.vcxproj">
+      <Project>{2e6c348c-c75c-4d94-8d1e-9c1fcbf3efe4}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(CoreDir)Common\SCMRevGen.vcxproj">
+      <Project>{41279555-f94f-4ebc-99de-af863c10c5c4}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(CoreDir)DiscIO\DiscIO.vcxproj">
+      <Project>{160bdc25-5626-4b0d-bdd8-2953d9777fb5}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(CoreDir)InputCommon\InputCommon.vcxproj">
+      <Project>{6bbd47cf-91fd-4077-b676-8b76980178a9}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(CoreDir)VideoCommon\VideoCommon.vcxproj">
+      <Project>{3de9ee35-3e91-4f27-a014-2866ad8c3fe3}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)Bochs_disasm\Bochs_disasm.vcxproj">
+      <Project>{8ada04d7-6db1-4da4-ab55-64fb12a0997b}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)cubeb\msvc\cubeb.vcxproj">
+      <Project>{8ea11166-6512-44fc-b7a5-a4d1ecc81170}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)enet\enet.vcxproj">
+      <Project>{cbc76802-c128-4b17-bf6c-23b08c313e5e}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)libusb\libusb_static_2013.vcxproj">
+      <Project>{349ee8f9-7d25-4909-aaf5-ff3fade72187}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)LZO\LZO.vcxproj">
+      <Project>{ab993f38-c31d-4897-b139-a620c42bc565}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)miniupnpc\miniupnpc.vcxproj">
+      <Project>{31643fdb-1bb8-4965-9de7-000fc88d35ae}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)mbedtls\mbedTLS.vcxproj">
+      <Project>{bdb6578b-0691-4e80-a46c-df21639fd3b8}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)minizip\minizip.vcxproj">
+      <Project>{23114507-079a-4418-9707-cfa81a03ca99}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)pugixml\pugixml.vcxproj">
+      <Project>{38fee76f-f347-484b-949c-b4649381cffb}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)SFML\build\vc2010\SFML_Network.vcxproj">
+      <Project>{93d73454-2512-424e-9cda-4bb357fe13dd}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -337,7 +337,17 @@ std::tuple<double, double> GCPad::GetPrimeStickXY()
 
 bool GCPad::CheckPitchRecentre()
 {
-  return m_primehack_stick->controls[5]->GetState() > 0.5;
+  // Check if L Button is pressed.
+  // This forces interpolation to stop while holding button for strafe so we don't have that jerking
+  // back to center When locking on since we've pressed or let go (if using NOT) of the recenter button.
+  // More accurately simulates the GC Prime freelook.
+  // TODO: adjust the recenter interpolation rate (or better yet, allows USERS to adjust recenter
+  // value) (function is elsewhere)
+  // Also, this isn't perfect because if the user aims again before recentering, the old rate will still exist, so maybe RESET rate???
+  if (m_triggers->controls[2]->GetState() > 0.5)
+    return false;
+  else
+    return m_primehack_stick->controls[5]->GetState() > 0.5;
 }
 
 bool GCPad::PrimeControllerMode()

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -337,7 +337,7 @@ std::tuple<double, double> GCPad::GetPrimeStickXY()
 
 bool GCPad::CheckPitchRecentre()
 {
-    return m_primehack_stick->controls[5]->GetState() > 0.5;
+  return m_primehack_stick->controls[5]->GetState() > 0.5;
 }
 
 bool GCPad::PrimeControllerMode()

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -337,16 +337,6 @@ std::tuple<double, double> GCPad::GetPrimeStickXY()
 
 bool GCPad::CheckPitchRecentre()
 {
-  // Check if L Button is pressed.
-  // This forces interpolation to stop while holding button for strafe so we don't have that jerking
-  // back to center When locking on since we've pressed or let go (if using NOT) of the recenter button.
-  // More accurately simulates the GC Prime freelook.
-  // TODO: adjust the recenter interpolation rate (or better yet, allows USERS to adjust recenter
-  // value) (function is elsewhere)
-  // Also, this isn't perfect because if the user aims again before recentering, the old rate will still exist, so maybe RESET rate???
-  if (m_triggers->controls[2]->GetState() > 0.5)
-    return false;
-  else
     return m_primehack_stick->controls[5]->GetState() > 0.5;
 }
 

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -815,7 +815,17 @@ std::tuple<double, double> Wiimote::GetPrimeStickXY()
 
 bool Wiimote::CheckPitchRecentre()
 {
-  return m_primehack_stick->controls[5]->GetState() > 0.5;
+  //Check if Nunchuk Z Button is pressed.
+  //This forces interpolation to stop while holding button for strafe so we don't have that jerking back to center
+  //When locking on since we've pressed or let go (if using NOT) of the recenter button
+  //More accurately simulates the GC Prime freelook.
+  //TODO: adjust the recenter interpolation rate (or better yet, allows USERS to adjust recenter value) (function is elsewhere)
+  // Also, this isn't perfect because if the user aims again before recentering, the old rate will still exist, so maybe RESET rate???
+  if (((WiimoteEmu::Nunchuk*)GetActiveExtension())->GetGroup(WiimoteEmu::NunchukGroup::Buttons)->controls[1]
+          ->GetState() > 0.5)
+    return false;
+  else
+    return m_primehack_stick->controls[5]->GetState() > 0.5;
 }
 
 std::tuple<bool, bool> Wiimote::GetBVMenuOptions()

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -815,7 +815,7 @@ std::tuple<double, double> Wiimote::GetPrimeStickXY()
 
 bool Wiimote::CheckPitchRecentre()
 {
-    return m_primehack_stick->controls[5]->GetState() > 0.5;
+  return m_primehack_stick->controls[5]->GetState() > 0.5;
 }
 
 std::tuple<bool, bool> Wiimote::GetBVMenuOptions()

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -39,6 +39,7 @@
 #include "InputCommon/ControllerEmu/Control/Output.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Attachments.h"
 #include "InputCommon/ControllerEmu/ControlGroup/PrimeHackModes.h"
+#include "InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Cursor.h"
@@ -343,6 +344,10 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
   m_primehack_visors->AddSetting(
     &m_primehack_visor_menu, {"Enable Visor Menu", nullptr, nullptr, _trans("Enable Visor Menu")}, false);
 
+  // PrimeHack Morphball Controls
+  // Menu options for this Group are stored in the WiimoteEmu files (WiimoteEmuMetroid.cpp, PrimeHackEmuWii.cpp, etc.)
+  groups.emplace_back(m_primehack_morphball_controls = new ControllerEmu::PrimeHackMorph(_trans("PrimeHack"), ""));
+
   groups.emplace_back(m_primehack_camera = new ControllerEmu::ControlGroup(_trans("PrimeHack")));
 
   m_primehack_camera->AddSetting(
@@ -475,6 +480,8 @@ ControllerEmu::ControlGroup* Wiimote::GetWiimoteGroup(WiimoteGroup group) const
     return m_primehack_stick;
   case WiimoteGroup::Modes:
     return m_primehack_modes;
+  case WiimoteGroup::MorphballControls:
+    return m_primehack_morphball_controls;
   default:
     ASSERT(false);
     return nullptr;

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -815,16 +815,6 @@ std::tuple<double, double> Wiimote::GetPrimeStickXY()
 
 bool Wiimote::CheckPitchRecentre()
 {
-  //Check if Nunchuk Z Button is pressed.
-  //This forces interpolation to stop while holding button for strafe so we don't have that jerking back to center
-  //When locking on since we've pressed or let go (if using NOT) of the recenter button
-  //More accurately simulates the GC Prime freelook.
-  //TODO: adjust the recenter interpolation rate (or better yet, allows USERS to adjust recenter value) (function is elsewhere)
-  // Also, this isn't perfect because if the user aims again before recentering, the old rate will still exist, so maybe RESET rate???
-  if (((WiimoteEmu::Nunchuk*)GetActiveExtension())->GetGroup(WiimoteEmu::NunchukGroup::Buttons)->controls[1]
-          ->GetState() > 0.5)
-    return false;
-  else
     return m_primehack_stick->controls[5]->GetState() > 0.5;
 }
 

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -24,6 +24,7 @@ namespace ControllerEmu
 {
 class Attachments;
 class PrimeHackModes;
+class PrimeHackMorph;
 class Buttons;
 class ControlGroup;
 class Cursor;
@@ -61,7 +62,8 @@ enum class WiimoteGroup
   Camera,
   Misc,
   ControlStick,
-  Modes
+  Modes,
+  MorphballControls
 };
 
 enum class NunchukGroup;
@@ -294,6 +296,7 @@ private:
   ControllerEmu::ControlGroup* m_primehack_motionhacks;
   ControllerEmu::ControlGroup* m_primehack_camera;
   ControllerEmu::ControlGroup* m_primehack_misc;
+  ControllerEmu::PrimeHackMorph* m_primehack_morphball_controls;
   ControllerEmu::PrimeHackModes* m_primehack_modes;
   ControllerEmu::AnalogStick* m_primehack_stick;
 

--- a/Source/Core/Core/PrimeHack/HackConfig.cpp
+++ b/Source/Core/Core/PrimeHack/HackConfig.cpp
@@ -268,7 +268,7 @@ std::pair<std::string, std::string> getProfiles()
 
   //Make sure we get the full path
   const std::string morph_profile_path = File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR +
-    Wiimote::GetConfig()->GetProfileName() + "/" + group->GetSelection() +
+    Wiimote::GetConfig()->GetProfileName() + "/" + group->GetMorphBallProfileName() +
     ".ini";
 
   //Make sure we get the full path
@@ -281,34 +281,23 @@ std::pair<std::string, std::string> getProfiles()
 
 void ChangeControllerProfileMorphBall(bool in_morphball, std::string profile_path)
 {
+  IniFile ini;
+  ini.Load(profile_path);
+
   if (in_morphball)
   {
-    //Always just get the first controller port
     //TODO: MAAAAYBE make this work for other ports?
-
     //Swap to morphball profile
-    
-    //Load the ini
-    IniFile ini;
-    ini.Load(profile_path);
-
+ 
     Wiimote::GetConfig()->GetController(0)->LoadConfig(ini.GetOrCreateSection("Profile"));
     Wiimote::GetConfig()->GetController(0)->UpdateReferences(g_controller_interface);
-
-    //const auto lock = Wiimote::GetConfig()->GetController(0)->GetStateLock();
   }
   else
   {
     //Swap back to main profile.
 
-    //Load the ini
-    IniFile ini;
-    ini.Load(profile_path);
-
     Wiimote::GetConfig()->GetController(0)->LoadConfig(ini.GetOrCreateSection("Profile"));
     Wiimote::GetConfig()->GetController(0)->UpdateReferences(g_controller_interface);
-
-    //const auto lock = Wiimote::GetConfig()->GetController(0)->GetStateLock();
   }
 }
 

--- a/Source/Core/Core/PrimeHack/HackConfig.cpp
+++ b/Source/Core/Core/PrimeHack/HackConfig.cpp
@@ -4,6 +4,11 @@
 #include <string>
 
 #include "Common/IniFile.h"
+#include "Common/CommonPaths.h"
+#include "Common/FileSearch.h"
+#include "Common/FileUtil.h"
+#include "Common/IniFile.h"
+#include "Common/StringUtil.h"
 
 #include "Core/PrimeHack/PrimeUtils.h"
 #include "Core/PrimeHack/EmuVariableManager.h"
@@ -33,9 +38,13 @@
 #include "Core/Config/GraphicsSettings.h"
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
+#include "InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h"
+#include "InputCommon/InputConfig.h"
 
 #include "VideoCommon/VideoConfig.h"
 #include <Core/Host.h>
+
+constexpr const char* PROFILES_DIR = "Profiles/";
 
 namespace prime {
 namespace {
@@ -249,6 +258,57 @@ std::tuple<float, float, float> GetArmXYZ() {
   float z = Config::Get(Config::ARMPOSITION_UPDOWN) / 100.f;
 
   return std::make_tuple(x, y, z);
+}
+
+// First is morphball profile, Second is main controller profile
+std::pair<std::string, std::string> getProfiles()
+{
+  auto* group = static_cast<ControllerEmu::PrimeHackMorph*>(
+    Wiimote::GetWiimoteGroup(0, WiimoteEmu::WiimoteGroup::MorphballControls));
+
+  //Make sure we get the full path
+  const std::string morph_profile_path = File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR +
+    Wiimote::GetConfig()->GetProfileName() + "/" + group->GetSelection() +
+    ".ini";
+
+  //Make sure we get the full path
+  const std::string main_profile_path = File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR +
+    Wiimote::GetConfig()->GetProfileName() + "/" + group->GetMainProfileName() +
+    ".ini";
+
+  return { morph_profile_path, main_profile_path };
+}
+
+void ChangeControllerProfileMorphBall(bool in_morphball, std::string profile_path)
+{
+  //If in morphball load morphball ini, otherwise we load the current profile
+  if (in_morphball)
+  {
+    //Always just get the first controller port
+    //TODO: MAAAAYBE make this work for other ports?
+    
+    //Load the ini
+    IniFile ini;
+    ini.Load(profile_path);
+
+    Wiimote::GetConfig()->GetController(0)->LoadConfig(ini.GetOrCreateSection("Profile"));
+    Wiimote::GetConfig()->GetController(0)->UpdateReferences(g_controller_interface);
+
+    //const auto lock = Wiimote::GetConfig()->GetController(0)->GetStateLock();
+  }
+  else
+  {
+    //Should swap back to main profile with this.
+
+    //Load the ini
+    IniFile ini;
+    ini.Load(profile_path);
+
+    Wiimote::GetConfig()->GetController(0)->LoadConfig(ini.GetOrCreateSection("Profile"));
+    Wiimote::GetConfig()->GetController(0)->UpdateReferences(g_controller_interface);
+
+    //const auto lock = Wiimote::GetConfig()->GetController(0)->GetStateLock();
+  }
 }
 
 void UpdateHackSettings() {

--- a/Source/Core/Core/PrimeHack/HackConfig.cpp
+++ b/Source/Core/Core/PrimeHack/HackConfig.cpp
@@ -281,11 +281,12 @@ std::pair<std::string, std::string> getProfiles()
 
 void ChangeControllerProfileMorphBall(bool in_morphball, std::string profile_path)
 {
-  //If in morphball load morphball ini, otherwise we load the current profile
   if (in_morphball)
   {
     //Always just get the first controller port
     //TODO: MAAAAYBE make this work for other ports?
+
+    //Swap to morphball profile
     
     //Load the ini
     IniFile ini;
@@ -298,7 +299,7 @@ void ChangeControllerProfileMorphBall(bool in_morphball, std::string profile_pat
   }
   else
   {
-    //Should swap back to main profile with this.
+    //Swap back to main profile.
 
     //Load the ini
     IniFile ini;

--- a/Source/Core/Core/PrimeHack/HackConfig.cpp
+++ b/Source/Core/Core/PrimeHack/HackConfig.cpp
@@ -267,14 +267,27 @@ std::pair<std::string, std::string> getProfiles()
     Wiimote::GetWiimoteGroup(0, WiimoteEmu::WiimoteGroup::MorphballControls));
 
   //Make sure we get the full path
-  const std::string morph_profile_path = File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR +
-    Wiimote::GetConfig()->GetProfileName() + "/" + group->GetMorphBallProfileName() +
-    ".ini";
+  const std::string morph_profname = group->GetMorphBallProfileName();
+  const std::string main_profname = group->GetMainProfileName();
+  std::string morph_profile_path;
+  std::string main_profile_path;
 
-  //Make sure we get the full path
-  const std::string main_profile_path = File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR +
-    Wiimote::GetConfig()->GetProfileName() + "/" + group->GetMainProfileName() +
-    ".ini";
+  //Prevent any goofiness.  If either profile name is empty just burn it all down...
+  //  Just kidding, simply return nothing in either string.
+  if (!morph_profname.empty() && !main_profname.empty())
+  {
+    morph_profile_path = File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR +
+      Wiimote::GetConfig()->GetProfileName() + "/" + group->GetMorphBallProfileName() +
+      ".ini";
+    main_profile_path = File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR +
+      Wiimote::GetConfig()->GetProfileName() + "/" + group->GetMainProfileName() +
+      ".ini";
+  }
+  else
+  {
+    morph_profile_path = "";
+    main_profile_path = "";
+  }
 
   return { morph_profile_path, main_profile_path };
 }

--- a/Source/Core/Core/PrimeHack/HackConfig.h
+++ b/Source/Core/Core/PrimeHack/HackConfig.h
@@ -76,6 +76,10 @@ CameraLock GetLockCamera();
 bool CheckPitchRecentre();
 bool ControllerMode();
 
+// Used to handle Morphball Controller Switch in WiimoteEmuMetroid.cpp, PrimeHackWiiEmu.cpp, etc.
+std::pair<std::string, std::string> getProfiles();
+void ChangeControllerProfileMorphBall(bool in_morphball, std::string profile);
+
 double GetHorizontalAxis();
 double GetVerticalAxis();
 

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
@@ -1,7 +1,7 @@
 #include "Core/PrimeHack/Mods/FpsControls.h"
 
 #include "Core/PrimeHack/Mods/ContextSensitiveControls.h"
-#include "Core/PrimeHack/PrimeUtils.h"
+#include "Core/PrimeHack/PrimeUtils.h"  //Loads HackConfig.h for us
 
 #include "Common/Timer.h"
 
@@ -670,6 +670,7 @@ void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
     } else {
       handle_cursor(cursor + 0x9c, cursor + 0x15c, active_region);
     }
+
   };
 
   // Handles menu screen cursor
@@ -778,6 +779,25 @@ void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
 
   // Nothing new here
   write32(0, angular_momentum + 0x18);
+
+  // If we just switched to morph ball then change controls,
+  //else if we were just in morph ball last frame but aren't this frame, then switch profile back.
+  //This is to avoid constantly load the same profile over and over as that would be slow.
+  u32 current_ball_state = read32(ball_state);
+  if (current_ball_state == 1 && !was_in_morph_ball)
+  {
+    //Tell HackConfig to switch the controller profile to Morph Ball preset
+    std::string profile = morphball_profile;
+    ChangeControllerProfileMorphBall(true, profile);
+    was_in_morph_ball = true;
+  }
+  else if (current_ball_state == 0 && was_in_morph_ball)
+  {
+    //Tell HackConfig to switch the controller profile back to the controller's previous preset.
+    std::string profile = default_profile;
+    ChangeControllerProfileMorphBall(false, profile);
+    was_in_morph_ball = false;
+  }
 }
 
 void FpsControls::CheckBeamVisorSetting(Game game)
@@ -1824,5 +1844,10 @@ void FpsControls::init_mod_mp3_standalone(Region region) {
     add_code_change(0x80017258, 0x48000120);
   } else {}
   has_beams = false;
+
+  //Setup the standard profiles from the .ini file for MP3 Only
+  std::pair<std::string, std::string> profiles = getProfiles();
+  morphball_profile = profiles.first;
+  default_profile = profiles.second;
 }
 }

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
@@ -780,23 +780,39 @@ void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
   // Nothing new here
   write32(0, angular_momentum + 0x18);
 
-  // If we just switched to morph ball then change controls,
-  //else if we were just in morph ball last frame but aren't this frame, then switch profile back.
+  //TODO: Need to fix one edge case.  Sometimes you can get stuck in morphball profile if you don't load/save a profile before exiting
+  //      the configuration menu.  Doesn't seem to happen consistently.
+  // 
+  //      Possible solution:  Change MappingWindow.cpp to force the loaded profile into the index upon opening the window.
+  //                          But right now, no text (that I know of) is being loaded into it, hence it being blank upon
+  //                          entry into the Emulated controller menu.  Might have to make an index variable to store index
+
+
   //This is to avoid constantly load the same profile over and over as that would be slow.
   u32 current_ball_state = read32(ball_state);
   if (current_ball_state == 1 && !was_in_morph_ball)
   {
     //Tell HackConfig to switch the controller profile to Morph Ball preset
     std::string profile = morphball_profile;
-    ChangeControllerProfileMorphBall(true, profile);
-    was_in_morph_ball = true;
+
+    //If empty, simply don't bother with this whole morphball profile nonsense.
+    if (!profile.empty())
+    {
+      ChangeControllerProfileMorphBall(true, profile);
+      was_in_morph_ball = true;
+    }
   }
   else if (current_ball_state == 0 && was_in_morph_ball)
   {
     //Tell HackConfig to switch the controller profile back to the controller's previous preset.
     std::string profile = default_profile;
-    ChangeControllerProfileMorphBall(false, profile);
-    was_in_morph_ball = false;
+
+    //If empty
+    if (!profile.empty())
+    {
+      ChangeControllerProfileMorphBall(false, profile);
+      was_in_morph_ball = false;
+    }
   }
 }
 

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.h
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.h
@@ -89,5 +89,10 @@ private:
 
   // Check when to reset the cursor position
   bool menu_open = true;
+
+  // Check if we were in the morph ball state last frame.
+  bool was_in_morph_ball = false;
+  std::string morphball_profile;
+  std::string default_profile;
 };
 }

--- a/Source/Core/DiscIO/DiscIO.vcxproj
+++ b/Source/Core/DiscIO/DiscIO.vcxproj
@@ -1,0 +1,111 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\VSProps\Base.Macros.props" />
+  <Import Project="$(VSPropsDir)Base.Targets.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{160BDC25-5626-4B0D-BDD8-2953D9777FB5}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VSPropsDir)Configuration.StaticLibrary.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VSPropsDir)Base.props" />
+    <Import Project="$(VSPropsDir)PCHUse.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Blob.cpp" />
+    <ClCompile Include="CISOBlob.cpp" />
+    <ClCompile Include="CompressedBlob.cpp" />
+    <ClCompile Include="DirectoryBlob.cpp" />
+    <ClCompile Include="DiscExtractor.cpp" />
+    <ClCompile Include="DiscScrubber.cpp" />
+    <ClCompile Include="DriveBlob.cpp" />
+    <ClCompile Include="Enums.cpp" />
+    <ClCompile Include="FileBlob.cpp" />
+    <ClCompile Include="Filesystem.cpp" />
+    <ClCompile Include="FileSystemGCWii.cpp" />
+    <ClCompile Include="LaggedFibonacciGenerator.cpp" />
+    <ClCompile Include="NANDImporter.cpp" />
+    <ClCompile Include="ScrubbedBlob.cpp" />
+    <ClCompile Include="TGCBlob.cpp" />
+    <ClCompile Include="Volume.cpp" />
+    <ClCompile Include="VolumeDisc.cpp" />
+    <ClCompile Include="VolumeFileBlobReader.cpp" />
+    <ClCompile Include="VolumeGC.cpp" />
+    <ClCompile Include="VolumeVerifier.cpp" />
+    <ClCompile Include="VolumeWad.cpp" />
+    <ClCompile Include="VolumeWii.cpp" />
+    <ClCompile Include="WbfsBlob.cpp" />
+    <ClCompile Include="WIABlob.cpp" />
+    <ClCompile Include="WIACompression.cpp" />
+    <ClCompile Include="WiiEncryptionCache.cpp" />
+    <ClCompile Include="WiiSaveBanner.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Blob.h" />
+    <ClInclude Include="CISOBlob.h" />
+    <ClInclude Include="CompressedBlob.h" />
+    <ClInclude Include="DirectoryBlob.h" />
+    <ClInclude Include="DiscExtractor.h" />
+    <ClInclude Include="DiscScrubber.h" />
+    <ClInclude Include="DriveBlob.h" />
+    <ClInclude Include="Enums.h" />
+    <ClInclude Include="FileBlob.h" />
+    <ClInclude Include="Filesystem.h" />
+    <ClInclude Include="FileSystemGCWii.h" />
+    <ClInclude Include="LaggedFibonacciGenerator.h" />
+    <ClInclude Include="MultithreadedCompressor.h" />
+    <ClInclude Include="NANDImporter.h" />
+    <ClInclude Include="ScrubbedBlob.h" />
+    <ClInclude Include="TGCBlob.h" />
+    <ClInclude Include="Volume.h" />
+    <ClInclude Include="VolumeDisc.h" />
+    <ClInclude Include="VolumeFileBlobReader.h" />
+    <ClInclude Include="VolumeGC.h" />
+    <ClInclude Include="VolumeVerifier.h" />
+    <ClInclude Include="VolumeWad.h" />
+    <ClInclude Include="VolumeWii.h" />
+    <ClInclude Include="WbfsBlob.h" />
+    <ClInclude Include="WIABlob.h" />
+    <ClInclude Include="WIACompression.h" />
+    <ClInclude Include="WiiEncryptionCache.h" />
+    <ClInclude Include="WiiSaveBanner.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CoreDir)Common\Common.vcxproj">
+      <Project>{2e6c348c-c75c-4d94-8d1e-9c1fcbf3efe4}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)bzip2\bzip2.vcxproj">
+      <Project>{055a775f-b4f5-4970-9240-f6cf7661f37b}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)liblzma\liblzma.vcxproj">
+      <Project>{1d8c51d2-ffa4-418e-b183-9f42b6a6717e}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)mbedtls\mbedTLS.vcxproj">
+      <Project>{bdb6578b-0691-4e80-a46c-df21639fd3b8}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)pugixml\pugixml.vcxproj">
+      <Project>{38fee76f-f347-484b-949c-b4649381cffb}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)zlib\zlib.vcxproj">
+      <Project>{ff213b23-2c26-4214-9f88-85271e557e87}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)zstd\zstd.vcxproj">
+      <Project>{1bea10f3-80ce-4bc4-9331-5769372cdf99}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Core/DolphinLib.vcxproj
+++ b/Source/Core/DolphinLib.vcxproj
@@ -36,22 +36,22 @@
   </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ClCompile>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <ClCompile>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/Core/DolphinLib.vcxproj
+++ b/Source/Core/DolphinLib.vcxproj
@@ -15,6 +15,18 @@
     <Import Project="$(VSPropsDir)PCHUse.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <EnableClangTidyCodeAnalysis>true</EnableClangTidyCodeAnalysis>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <EnableClangTidyCodeAnalysis>true</EnableClangTidyCodeAnalysis>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <EnableClangTidyCodeAnalysis>true</EnableClangTidyCodeAnalysis>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <EnableClangTidyCodeAnalysis>true</EnableClangTidyCodeAnalysis>
+  </PropertyGroup>
   <Import Project="DolphinLib.props" />
   <ImportGroup Condition="'$(Platform)'=='x64'">
     <Import Project="DolphinLib.x64.props" />
@@ -24,7 +36,22 @@
   </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -55,6 +82,7 @@
     <ClCompile Include="InputCommon\ControllerEmu\ControlGroup\PrimeHackModes.cpp" />
     <ClCompile Include="InputCommon\DInputMouseAbsolute.cpp" />
     <ClCompile Include="InputCommon\GenericMouse.cpp" />
+    <ClCompile Include="InputCommon\ControllerEmu\ControlGroup\PrimeHackMorph.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Core\PrimeHack\AddressDB.h" />
@@ -83,6 +111,7 @@
     <ClInclude Include="InputCommon\ControllerEmu\ControlGroup\PrimeHackModes.h" />
     <ClInclude Include="InputCommon\DInputMouseAbsolute.h" />
     <ClInclude Include="InputCommon\GenericMouse.h" />
+    <ClInclude Include="InputCommon\ControllerEmu\ControlGroup\PrimeHackMorph.h" />
     <ClInclude Include="VideoCommon\PrimePixelErrorTextures.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Source/Core/DolphinNoGUI/DolphinNoGUI.vcxproj
+++ b/Source/Core/DolphinNoGUI/DolphinNoGUI.vcxproj
@@ -23,7 +23,16 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp20</LanguageStandard>
+    </ClCompile>
+    <ClCompile>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpp20</LanguageStandard>
+    </ClCompile>
+    <ClCompile>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpp20</LanguageStandard>
+    </ClCompile>
+    <ClCompile>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/Core/DolphinNoGUI/DolphinNoGUI.vcxproj
+++ b/Source/Core/DolphinNoGUI/DolphinNoGUI.vcxproj
@@ -23,6 +23,7 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <ClCompile>
+<<<<<<< HEAD
       <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp20</LanguageStandard>
     </ClCompile>
     <ClCompile>
@@ -33,6 +34,9 @@
     </ClCompile>
     <ClCompile>
       <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp20</LanguageStandard>
+=======
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+>>>>>>> 426aae7624b00b77d1243cb24b9ebfcfd612139a
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/Core/DolphinNoGUI/DolphinNoGUI.vcxproj
+++ b/Source/Core/DolphinNoGUI/DolphinNoGUI.vcxproj
@@ -23,20 +23,16 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <ClCompile>
-<<<<<<< HEAD
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpplatest</LanguageStandard>
     </ClCompile>
     <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpplatest</LanguageStandard>
     </ClCompile>
     <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpplatest</LanguageStandard>
     </ClCompile>
     <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp20</LanguageStandard>
-=======
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
->>>>>>> 426aae7624b00b77d1243cb24b9ebfcfd612139a
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpplatest</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -9,6 +9,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QPushButton>
+#include <qstringbuilder.h>
 
 #include "DolphinQt/Config/Mapping/IOWindow.h"
 #include "DolphinQt/Config/Mapping/MappingButton.h"
@@ -51,9 +52,12 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
   QGroupBox* group_box = new QGroupBox(name);
   QFormLayout* form_layout = new QFormLayout();
 
-  group_box->setLayout(form_layout);
+  QHBoxLayout* m_morph_profiles_layout = nullptr;
+  QComboBox* m_morph_profiles_combo = nullptr;
 
   MappingIndicator* indicator = nullptr;
+
+  group_box->setLayout(form_layout);
 
   switch (group->type)
   {
@@ -88,6 +92,21 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
 
   case ControllerEmu::GroupType::Stick:
     indicator = new AnalogStickIndicator(*static_cast<ControllerEmu::ReshapableInput*>(group));
+    break;
+
+  case ControllerEmu::GroupType::PrimeHackMorph:
+    m_morph_profiles_layout = new QHBoxLayout();
+    m_morph_profiles_combo = new QComboBox();
+    m_morph_profiles_combo->setObjectName(tr("ProfileList"));
+
+    //PrimeHack Morphball Controls Layout added to default group layout.
+    form_layout->addRow(m_morph_profiles_layout);
+
+    m_morph_profiles_combo->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+    m_morph_profiles_combo->setMinimumWidth(200);
+    m_morph_profiles_combo->setEditable(true);
+
+    m_morph_profiles_layout->addWidget(m_morph_profiles_combo);
     break;
 
   default:

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -15,6 +15,8 @@
 
 #include "Core/Core.h"
 #include "Core/HotkeyManager.h"
+#include "Core/HW/Wiimote.h"
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include "Common/CommonPaths.h"
 #include "Common/FileSearch.h"
@@ -55,6 +57,7 @@
 #include "DolphinQt/Settings.h"
 
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 #include "InputCommon/InputConfig.h"
@@ -306,6 +309,15 @@ void MappingWindow::OnSaveProfilePressed()
 
   if (profile_name.isEmpty())
     return;
+  else
+  {
+    //Make absolutely sure we get the current profile name to save in PrimeHackMorph object
+    auto* morph_group = static_cast<ControllerEmu::PrimeHackMorph*>(
+      Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
+
+    std::string prof_name = profile_name.toStdString();
+    morph_group->SetMainProfileName(prof_name);
+  }
 
   const std::string profile_path = File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR +
                                    m_config->GetProfileName() + "/" + profile_name.toStdString() +
@@ -320,6 +332,7 @@ void MappingWindow::OnSaveProfilePressed()
 
   if (m_profiles_combo->findText(profile_name) == -1)
   {
+
     PopulateProfileSelection();
     m_profiles_combo->setCurrentIndex(m_profiles_combo->findText(profile_name));
   }
@@ -550,6 +563,11 @@ QWidget* MappingWindow::AddWidget(const QString& name, QWidget* widget)
 int MappingWindow::GetPort() const
 {
   return m_port;
+}
+
+std::string MappingWindow::GetProfileName() const
+{
+  return m_profiles_combo->currentText().toStdString();
 }
 
 ControllerEmu::EmulatedController* MappingWindow::GetController() const

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
@@ -52,6 +52,7 @@ public:
   explicit MappingWindow(QWidget* parent, Type type, int port_num);
 
   int GetPort() const;
+  std::string GetProfileName() const;
   ControllerEmu::EmulatedController* GetController() const;
   bool IsMappingAllDevices() const;
   void ShowExtensionMotionTabs(bool show);

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
@@ -20,13 +20,16 @@
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
 #include "Core/PrimeHack/HackConfig.h"
+#include "Core/PrimeHack/HackManager.h"
 
 #include "DolphinQt/Config/Mapping/WiimoteEmuExtension.h"
+#include "DolphinQt/Config/Mapping/MappingWindow.h"
 
 #include "InputCommon/ControllerEmu/ControlGroup/Attachments.h"
 #include "InputCommon/ControllerEmu/ControlGroup/PrimeHackModes.h"
 #include "InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h"
 #include "InputCommon/InputConfig.h"
+
 
 #include <QDesktopServices>
 #include <QUrl>
@@ -283,10 +286,17 @@ void WiimoteEmuMetroid::LoadSettings()
   QString text = tr(morph_group->GetSelection().c_str());
 
   m_morphball_combobox->setCurrentIndex(m_morphball_combobox->findText(text));
+
 }
 
 void WiimoteEmuMetroid::SaveSettings()
 {
+  //Make sure to populate profile into morphball group before it's updated by controller saveconfig.
+  auto* morph_group = static_cast<ControllerEmu::PrimeHackMorph*>(
+    Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
+  std::string profile_name = GetParent()->GetProfileName();
+  morph_group->SetMainProfileName(profile_name);
+
   Wiimote::GetConfig()->SaveConfig();
 
   prime::UpdateHackSettings();

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
@@ -234,7 +234,7 @@ void WiimoteEmuMetroid::OnMorphControlSelectionChanged()
       Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
 
   std::string curr_text = m_morphball_combobox->currentText().toStdString();
-  morph_group->SetSelection(curr_text);
+  morph_group->SetMorphBallProfileName(curr_text);
 
   //TODO: Find a nice way to fix saving "NONE" for the profile.  Maybe pull it directly from the currently selected control's ini file.
 
@@ -285,7 +285,7 @@ void WiimoteEmuMetroid::LoadSettings()
   m_radio_controller->setChecked(!checked);
   camera_control->setEnabled(!checked);
 
-  QString text = tr(morph_group->GetSelection().c_str());
+  QString text = tr(morph_group->GetMorphBallProfileName().c_str());
 
   m_morphball_combobox->setCurrentIndex(m_morphball_combobox->findText(text));
 

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
@@ -236,6 +236,8 @@ void WiimoteEmuMetroid::OnMorphControlSelectionChanged()
   std::string curr_text = m_morphball_combobox->currentText().toStdString();
   morph_group->SetSelection(curr_text);
 
+  //TODO: Find a nice way to fix saving "NONE" for the profile.  Maybe pull it directly from the currently selected control's ini file.
+
   ConfigChanged();
   SaveSettings();
 }
@@ -291,12 +293,6 @@ void WiimoteEmuMetroid::LoadSettings()
 
 void WiimoteEmuMetroid::SaveSettings()
 {
-  //Make sure to populate profile into morphball group before it's updated by controller saveconfig.
-  auto* morph_group = static_cast<ControllerEmu::PrimeHackMorph*>(
-    Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
-  std::string profile_name = GetParent()->GetProfileName();
-  morph_group->SetMainProfileName(profile_name);
-
   Wiimote::GetConfig()->SaveConfig();
 
   prime::UpdateHackSettings();

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
@@ -13,20 +13,25 @@
 #include <QRadioButton>
 #include <QTimer>
 
+#include "Common/FileUtil.h"
+#include "Common/FileSearch.h"
+
 #include "Core/HW/Wiimote.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
 #include "Core/PrimeHack/HackConfig.h"
 
-#include "DolphinQt/Config/Mapping/MappingWindow.h"
 #include "DolphinQt/Config/Mapping/WiimoteEmuExtension.h"
 
 #include "InputCommon/ControllerEmu/ControlGroup/Attachments.h"
 #include "InputCommon/ControllerEmu/ControlGroup/PrimeHackModes.h"
+#include "InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h"
 #include "InputCommon/InputConfig.h"
 
 #include <QDesktopServices>
 #include <QUrl>
+
+constexpr const char* PROFILES_DIR = "Profiles/";
 
 WiimoteEmuMetroid::WiimoteEmuMetroid(MappingWindow* window, WiimoteEmuExtension* extension)
     : MappingWidget(window), m_extension_widget(extension)
@@ -42,6 +47,40 @@ WiimoteEmuMetroid::WiimoteEmuMetroid(MappingWindow* window, WiimoteEmuExtension*
 
   ConfigChanged();
   SaveSettings();
+}
+
+void WiimoteEmuMetroid::PopulateMorphBallProfiles(QComboBox* combobox)
+{
+  combobox->clear();
+
+  const std::string profiles_path =
+      File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR + GetConfig()->GetProfileName();
+  for (const auto& filename : Common::DoFileSearch({profiles_path}, {".ini"}))
+  {
+    std::string basename;
+    SplitPath(filename, nullptr, &basename, nullptr);
+    if (!basename.empty())  // Ignore files with an empty name to avoid multiple problems
+      combobox->addItem(QString::fromStdString(basename),
+                                      QString::fromStdString(filename));
+  }
+
+  combobox->insertSeparator(combobox->count());
+
+  const std::string builtin_profiles_path =
+      File::GetSysDirectory() + PROFILES_DIR + GetConfig()->GetProfileName();
+  for (const auto& filename : Common::DoFileSearch({builtin_profiles_path}, {".ini"}))
+  {
+    std::string basename;
+    SplitPath(filename, nullptr, &basename, nullptr);
+    if (!basename.empty())
+    {
+      // i18n: "Stock" refers to input profiles included with Dolphin
+      combobox->addItem(tr("%1 (Stock)").arg(QString::fromStdString(basename)),
+                                      QString::fromStdString(filename));
+    }
+  }
+
+  combobox->setCurrentIndex(-1);
 }
 
 void WiimoteEmuMetroid::CreateMainLayout()
@@ -94,6 +133,13 @@ void WiimoteEmuMetroid::CreateMainLayout()
   auto* visor_box = CreateGroupBox(tr("Visors"), Wiimote::GetWiimoteGroup(
       GetPort(), WiimoteEmu::WiimoteGroup::Visors));
   groupbox1->addWidget(visor_box);
+
+  auto* morphball_control_box = CreateGroupBox(tr("Morphball Controller Profile"), Wiimote::GetWiimoteGroup(
+    GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
+  groupbox1->addWidget(morphball_control_box);
+  m_morphball_combobox = (morphball_control_box->findChild<QComboBox*>(tr("ProfileList")));
+  m_morphball_combobox->setToolTip(tr("Set the controller profile to use\nwhen in Morph Ball in MP3."));
+  PopulateMorphBallProfiles(m_morphball_combobox);
 
 
   auto* rumble_box = CreateGroupBox(tr("Rumble"), Wiimote::GetWiimoteGroup(
@@ -163,6 +209,7 @@ void WiimoteEmuMetroid::Connect()
     &WiimoteEmuMetroid::OnDeviceSelected);
   connect(m_radio_controller, &QRadioButton::toggled, this,
     &WiimoteEmuMetroid::OnDeviceSelected);
+  connect(m_morphball_combobox, &QComboBox::currentTextChanged, this, &WiimoteEmuMetroid::OnMorphControlSelectionChanged);
 }
 
 void WiimoteEmuMetroid::OnDeviceSelected()
@@ -172,6 +219,19 @@ void WiimoteEmuMetroid::OnDeviceSelected()
 
   ce_modes->SetSelectedDevice(m_radio_mouse->isChecked() ? 0 : 1);
   camera_control->setEnabled(!m_radio_mouse->isChecked());
+
+  ConfigChanged();
+  SaveSettings();
+}
+
+void WiimoteEmuMetroid::OnMorphControlSelectionChanged()
+{
+  //Called as soon as our selection is changed to update the controller preset for Morphball mode.
+  auto* morph_group = static_cast<ControllerEmu::PrimeHackMorph*>(
+      Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
+
+  std::string curr_text = m_morphball_combobox->currentText().toStdString();
+  morph_group->SetSelection(curr_text);
 
   ConfigChanged();
   SaveSettings();
@@ -198,6 +258,9 @@ void WiimoteEmuMetroid::LoadSettings()
 {
   Wiimote::LoadConfig(); // No need to update hack settings since it's already in LoadConfig.
 
+  auto* morph_group = static_cast<ControllerEmu::PrimeHackMorph*>(
+    Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
+
   auto* modes = static_cast<ControllerEmu::PrimeHackModes*>(
     Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Modes));
 
@@ -216,6 +279,10 @@ void WiimoteEmuMetroid::LoadSettings()
   m_radio_mouse->setChecked(checked);
   m_radio_controller->setChecked(!checked);
   camera_control->setEnabled(!checked);
+
+  QString text = tr(morph_group->GetSelection().c_str());
+
+  m_morphball_combobox->setCurrentIndex(m_morphball_combobox->findText(text));
 }
 
 void WiimoteEmuMetroid::SaveSettings()

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
@@ -22,8 +22,8 @@
 #include "Core/PrimeHack/HackConfig.h"
 #include "Core/PrimeHack/HackManager.h"
 
-#include "DolphinQt/Config/Mapping/WiimoteEmuExtension.h"
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
+#include "DolphinQt/Config/Mapping/WiimoteEmuExtension.h"
 
 #include "InputCommon/ControllerEmu/ControlGroup/Attachments.h"
 #include "InputCommon/ControllerEmu/ControlGroup/PrimeHackModes.h"

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.h
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.h
@@ -6,6 +6,8 @@
 
 #include "DolphinQt/Config/Mapping/MappingWidget.h"
 
+class QHBoxLayout;
+class QGroupBox;
 class QComboBox;
 class QLabel;
 class QRadioButton;
@@ -23,13 +25,17 @@ public:
   QRadioButton* m_radio_mouse;
   QRadioButton* m_radio_controller;
   QPushButton* m_help_button;
+  QComboBox* m_morphball_combobox;
+
 private:
   void LoadSettings() override;
   void SaveSettings() override;
   void CreateMainLayout();
+  void PopulateMorphBallProfiles(QComboBox* combobox);
   void Connect();
 
   void OnDeviceSelected();
+  void OnMorphControlSelectionChanged();
   void ConfigChanged();
   void Update();
 

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.h
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.h
@@ -12,6 +12,7 @@ class QComboBox;
 class QLabel;
 class QRadioButton;
 class WiimoteEmuExtension;
+class MappingWindow;
 
 class WiimoteEmuMetroid final : public MappingWidget
 {

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.h
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.h
@@ -12,7 +12,6 @@ class QComboBox;
 class QLabel;
 class QRadioButton;
 class WiimoteEmuExtension;
-class MappingWindow;
 
 class WiimoteEmuMetroid final : public MappingWidget
 {

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -17,6 +17,12 @@
     <Import Project="$(VSPropsDir)QtCompile.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <EnableClangTidyCodeAnalysis>false</EnableClangTidyCodeAnalysis>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <EnableClangTidyCodeAnalysis>false</EnableClangTidyCodeAnalysis>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <!-- 5054  operator '+': deprecated between enumerations of different types (in Qt headers) -->
@@ -37,7 +43,10 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>avrt.lib;iphlpapi.lib;winmm.lib;setupapi.lib;rpcrt4.lib;comctl32.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -43,10 +43,10 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Use</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp20</LanguageStandard>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpp20</LanguageStandard>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpp20</LanguageStandard>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>avrt.lib;iphlpapi.lib;winmm.lib;setupapi.lib;rpcrt4.lib;comctl32.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -130,10 +130,9 @@ void ControlGroup::LoadConfig(IniFile::Section* sec, const std::string& defdev,
 
     std::string prof;
     sec->Get(base + name + "/MorphBallProfile", &prof);
-    ext->SetSelection(prof);
-    std::string mainprof;
-    sec->Get(base + name + "/MainProfileName", &mainprof);
-    ext->SetMainProfileName(mainprof);
+    ext->SetMorphBallProfileName(prof);
+    sec->Get(base + name + "/MainProfileName", &prof);
+    ext->SetMainProfileName(prof);
   }
 }
 
@@ -201,7 +200,7 @@ void ControlGroup::SaveConfig(IniFile::Section* sec, const std::string& defdev,
   {
     auto* const ext = static_cast<PrimeHackMorph*>(this);
 
-    sec->Set(base + name + "/MorphBallProfile", ext->GetSelection());
+    sec->Set(base + name + "/MorphBallProfile", ext->GetMorphBallProfileName());
     sec->Set(base + name + "/MainProfileName", ext->GetMainProfileName());
   }
 }

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -13,6 +13,7 @@
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 #include "InputCommon/ControllerEmu/ControlGroup/PrimeHackModes.h"
+#include "InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h"
 
 namespace ControllerEmu
 {
@@ -114,13 +115,22 @@ void ControlGroup::LoadConfig(IniFile::Section* sec, const std::string& defdev,
   }
 
   // extensions
-  if (type == GroupType::PrimeHack)
+  if (type == GroupType::PrimeHackMode)
   {
     auto* const ext = static_cast<PrimeHackModes*>(this);
 
     std::string i;
     sec->Get(base + name + "/Mode", &i, "0");
     ext->SetSelectedDevice(stoi(i));
+  }
+
+  if (type == GroupType::PrimeHackMorph)
+  {
+    auto* const ext = static_cast<PrimeHackMorph*>(this);
+
+    std::string prof;
+    sec->Get(base + name + "/MorphBallProfile", &prof);
+    ext->SetSelection(prof);
   }
 }
 
@@ -177,11 +187,18 @@ void ControlGroup::SaveConfig(IniFile::Section* sec, const std::string& defdev,
       ai->SaveConfig(sec, base + ai->GetName() + "/");
   }
 
-  if (type == GroupType::PrimeHack)
+  if (type == GroupType::PrimeHackMode)
   {
     auto* const ext = static_cast<PrimeHackModes*>(this);
 
     sec->Set(base + name + "/Mode", std::to_string(ext->GetSelectedDevice()), "0");
+  }
+
+  if (type == GroupType::PrimeHackMorph)
+  {
+    auto* const ext = static_cast<PrimeHackMorph*>(this);
+
+    sec->Set(base + name + "/MorphBallProfile", ext->GetSelection());
   }
 }
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -131,6 +131,9 @@ void ControlGroup::LoadConfig(IniFile::Section* sec, const std::string& defdev,
     std::string prof;
     sec->Get(base + name + "/MorphBallProfile", &prof);
     ext->SetSelection(prof);
+    std::string mainprof;
+    sec->Get(base + name + "/MainProfileName", &mainprof);
+    ext->SetMainProfileName(mainprof);
   }
 }
 
@@ -199,6 +202,7 @@ void ControlGroup::SaveConfig(IniFile::Section* sec, const std::string& defdev,
     auto* const ext = static_cast<PrimeHackMorph*>(this);
 
     sec->Set(base + name + "/MorphBallProfile", ext->GetSelection());
+    sec->Set(base + name + "/MainProfileName", ext->GetMainProfileName());
   }
 }
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -43,7 +43,8 @@ enum class GroupType
   IMUAccelerometer,
   IMUGyroscope,
   IMUCursor,
-  PrimeHack
+  PrimeHackMode,
+  PrimeHackMorph
 };
 
 class ControlGroup

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackModes.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackModes.cpp
@@ -3,7 +3,7 @@
 
 namespace ControllerEmu
 {
-  PrimeHackModes::PrimeHackModes(const std::string& name_) : ControlGroup(name_, GroupType::PrimeHack)
+  PrimeHackModes::PrimeHackModes(const std::string& name_) : ControlGroup(name_, GroupType::PrimeHackMode)
   {
   }
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.cpp
@@ -14,8 +14,19 @@ namespace ControllerEmu
     return m_selection_value;
   }
 
+  const std::string& PrimeHackMorph::GetMainProfileName() const
+  {
+    return m_previous_selection;
+  }
+
   void PrimeHackMorph::SetSelection(std::string& val)
   {
     m_selection_value = val;
+  }
+
+  //Used to store the original profile from the main profile for the current WiimoteEmu Window
+  void PrimeHackMorph::SetMainProfileName(std::string& val)
+  {
+    m_previous_selection = val;
   }
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.cpp
@@ -1,0 +1,21 @@
+#include "InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h"
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
+
+namespace ControllerEmu
+{
+  PrimeHackMorph::PrimeHackMorph(const std::string& name_, const std::string& default_selection)
+    : ControlGroup(name_, GroupType::PrimeHackMorph), m_selection_value(default_selection)
+  {
+  }
+
+    // Always return controller mode for platforms with input APIs we don't support.
+  const std::string& PrimeHackMorph::GetSelection() const
+  {
+    return m_selection_value;
+  }
+
+  void PrimeHackMorph::SetSelection(std::string& val)
+  {
+    m_selection_value = val;
+  }
+}  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.cpp
@@ -8,8 +8,8 @@ namespace ControllerEmu
   {
   }
 
-    // Always return controller mode for platforms with input APIs we don't support.
-  const std::string& PrimeHackMorph::GetSelection() const
+    // Returns the MorphBall Profile
+  const std::string& PrimeHackMorph::GetMorphBallProfileName() const
   {
     return m_selection_value;
   }
@@ -19,12 +19,11 @@ namespace ControllerEmu
     return m_previous_selection;
   }
 
-  void PrimeHackMorph::SetSelection(std::string& val)
+  void PrimeHackMorph::SetMorphBallProfileName(std::string& val)
   {
     m_selection_value = val;
   }
 
-  //Used to store the original profile from the main profile for the current WiimoteEmu Window
   void PrimeHackMorph::SetMainProfileName(std::string& val)
   {
     m_previous_selection = val;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h
@@ -21,9 +21,9 @@ namespace ControllerEmu
   public:
     explicit PrimeHackMorph(const std::string& name, const std::string& default_selection);
 
-    const std::string& GetSelection() const;
+    const std::string& GetMorphBallProfileName() const;
     const std::string& GetMainProfileName() const;
-    void SetSelection(std::string& val);
+    void SetMorphBallProfileName(std::string& val);
     void SetMainProfileName(std::string& val);
 
   private:

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h
@@ -22,9 +22,12 @@ namespace ControllerEmu
     explicit PrimeHackMorph(const std::string& name, const std::string& default_selection);
 
     const std::string& GetSelection() const;
+    const std::string& GetMainProfileName() const;
     void SetSelection(std::string& val);
+    void SetMainProfileName(std::string& val);
 
   private:
     std::string m_selection_value;
+    std::string m_previous_selection;
   };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h
@@ -1,0 +1,30 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "Common/CommonTypes.h"
+#include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
+
+namespace ControllerEmu
+{
+  class PrimeHackMorph : public ControlGroup
+  {
+  public:
+    explicit PrimeHackMorph(const std::string& name, const std::string& default_selection);
+
+    const std::string& GetSelection() const;
+    void SetSelection(std::string& val);
+
+  private:
+    std::string m_selection_value;
+  };
+}  // namespace ControllerEmu

--- a/Source/Core/InputCommon/InputCommon.vcxproj
+++ b/Source/Core/InputCommon/InputCommon.vcxproj
@@ -1,0 +1,127 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\VSProps\Base.Macros.props" />
+  <Import Project="$(VSPropsDir)Base.Targets.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{6BBD47CF-91FD-4077-B676-8B76980178A9}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VSPropsDir)Configuration.StaticLibrary.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VSPropsDir)Base.props" />
+    <Import Project="$(VSPropsDir)PCHUse.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="ControllerEmu\ControlGroup\IMUAccelerometer.cpp" />
+    <ClCompile Include="ControllerEmu\ControlGroup\IMUCursor.cpp" />
+    <ClCompile Include="ControllerEmu\ControlGroup\IMUGyroscope.cpp" />
+    <ClCompile Include="ControllerEmu\ControlGroup\PrimeHackModes.cpp" />
+    <ClCompile Include="ControllerEmu\ControllerEmu.cpp" />
+    <ClCompile Include="ControllerEmu\StickGate.cpp" />
+    <ClCompile Include="ControllerEmu\Control\Control.cpp" />
+    <ClCompile Include="ControllerEmu\Control\Input.cpp" />
+    <ClCompile Include="ControllerEmu\Control\Output.cpp" />
+    <ClCompile Include="ControllerEmu\ControlGroup\AnalogStick.cpp" />
+    <ClCompile Include="ControllerEmu\ControlGroup\Buttons.cpp" />
+    <ClCompile Include="ControllerEmu\ControlGroup\ControlGroup.cpp" />
+    <ClCompile Include="ControllerEmu\ControlGroup\Cursor.cpp" />
+    <ClCompile Include="ControllerEmu\ControlGroup\Attachments.cpp" />
+    <ClCompile Include="ControllerEmu\ControlGroup\Force.cpp" />
+    <ClCompile Include="ControllerEmu\ControlGroup\MixedTriggers.cpp" />
+    <ClCompile Include="ControllerEmu\ControlGroup\ModifySettingsButton.cpp" />
+    <ClCompile Include="ControllerEmu\ControlGroup\Slider.cpp" />
+    <ClCompile Include="ControllerEmu\ControlGroup\Tilt.cpp" />
+    <ClCompile Include="ControllerEmu\ControlGroup\Triggers.cpp" />
+    <ClCompile Include="ControllerEmu\Setting\NumericSetting.cpp" />
+    <ClCompile Include="ControllerInterface\ControllerInterface.cpp" />
+    <ClCompile Include="ControllerInterface\Device.cpp" />
+    <ClCompile Include="ControllerInterface\DInput\DInput.cpp" />
+    <ClCompile Include="ControllerInterface\DInput\DInputJoystick.cpp" />
+    <ClCompile Include="ControllerInterface\DInput\DInputKeyboardMouse.cpp" />
+    <ClCompile Include="ControllerInterface\DInput\XInputFilter.cpp" />
+    <ClCompile Include="ControllerInterface\DualShockUDPClient\DualShockUDPClient.cpp" />
+    <ClCompile Include="ControlReference\ControlReference.cpp" />
+    <ClCompile Include="ControlReference\ExpressionParser.cpp" />
+    <ClCompile Include="ControllerInterface\ForceFeedback\ForceFeedbackDevice.cpp" />
+    <ClCompile Include="ControllerInterface\Win32\Win32.cpp" />
+    <ClCompile Include="ControllerInterface\Wiimote\Wiimote.cpp" />
+    <ClCompile Include="ControllerInterface\XInput\XInput.cpp" />
+    <ClCompile Include="ControlReference\FunctionExpression.cpp" />
+    <ClCompile Include="DynamicInputTextureConfiguration.cpp" />
+    <ClCompile Include="DynamicInputTextureManager.cpp" />
+    <ClCompile Include="GCAdapter.cpp" />
+    <ClCompile Include="ImageOperations.cpp" />
+    <ClCompile Include="InputConfig.cpp" />
+    <ClCompile Include="InputProfile.cpp" />
+    <ClCompile Include="DInputMouseAbsolute.cpp" />
+    <ClCompile Include="GenericMouse.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="ControllerEmu\ControlGroup\IMUAccelerometer.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\IMUCursor.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\IMUGyroscope.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\PrimeHackModes.h" />
+    <ClInclude Include="ControllerEmu\ControllerEmu.h" />
+    <ClInclude Include="ControllerEmu\StickGate.h" />
+    <ClInclude Include="ControllerEmu\Control\Control.h" />
+    <ClInclude Include="ControllerEmu\Control\Input.h" />
+    <ClInclude Include="ControllerEmu\Control\Output.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\AnalogStick.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\Buttons.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\ControlGroup.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\Cursor.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\Attachments.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\Force.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\MixedTriggers.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\ModifySettingsButton.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\Slider.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\Tilt.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\Triggers.h" />
+    <ClInclude Include="ControllerEmu\Setting\NumericSetting.h" />
+    <ClInclude Include="ControllerInterface\ControllerInterface.h" />
+    <ClInclude Include="ControllerInterface\Device.h" />
+    <ClInclude Include="ControllerInterface\DInput\DInput.h" />
+    <ClInclude Include="ControllerInterface\DInput\DInput8.h" />
+    <ClInclude Include="ControllerInterface\DInput\DInputJoystick.h" />
+    <ClInclude Include="ControllerInterface\DInput\DInputKeyboardMouse.h" />
+    <ClInclude Include="ControllerInterface\DInput\XInputFilter.h" />
+    <ClInclude Include="ControllerInterface\DualShockUDPClient\DualShockUDPClient.h" />
+    <ClInclude Include="ControllerInterface\DualShockUDPClient\DualShockUDPProto.h" />
+    <ClInclude Include="ControlReference\ControlReference.h" />
+    <ClInclude Include="ControlReference\FunctionExpression.h" />
+    <ClInclude Include="ControlReference\ExpressionParser.h" />
+    <ClInclude Include="ControllerInterface\ForceFeedback\ForceFeedbackDevice.h" />
+    <ClInclude Include="ControllerInterface\Win32\Win32.h" />
+    <ClInclude Include="ControllerInterface\Wiimote\Wiimote.h" />
+    <ClInclude Include="ControllerInterface\XInput\XInput.h" />
+    <ClInclude Include="DynamicInputTextureConfiguration.h" />
+    <ClInclude Include="DynamicInputTextureManager.h" />
+    <ClInclude Include="GCAdapter.h" />
+    <ClInclude Include="GCPadStatus.h" />
+    <ClInclude Include="ImageOperations.h" />
+    <ClInclude Include="InputConfig.h" />
+    <ClInclude Include="InputProfile.h" />
+    <ClInclude Include="DInputMouseAbsolute.h" />
+    <ClInclude Include="GenericMouse.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CoreDir)Common\Common.vcxproj">
+      <Project>{2e6c348c-c75c-4d94-8d1e-9c1fcbf3efe4}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Core/InputCommon/InputCommon.vcxproj.filters
+++ b/Source/Core/InputCommon/InputCommon.vcxproj.filters
@@ -1,0 +1,261 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="ControllerInterface">
+      <UniqueIdentifier>{3a755a86-0efa-4396-bf79-bb3a1910764d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ControllerInterface\ForceFeedback">
+      <UniqueIdentifier>{e10ce316-283c-4be0-848d-578dec2b6404}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ControllerEmu">
+      <UniqueIdentifier>{4c839215-4085-4e34-a960-7960986ad015}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ControllerEmu\Control">
+      <UniqueIdentifier>{19ddd862-a1e3-479b-b638-bb31700c5171}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ControllerEmu\ControlGroup">
+      <UniqueIdentifier>{e805231c-dc4e-4540-8bf8-8c567f3d00ae}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ControllerEmu\Setting">
+      <UniqueIdentifier>{ce661cb4-f23f-4ab2-952d-402d381735e5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ControllerInterface\Win32">
+      <UniqueIdentifier>{6ca06b20-d8f6-4622-97ab-eefbc66edbd5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ControllerInterface\DInput">
+      <UniqueIdentifier>{0289ef91-50f5-4c16-9fa4-ff4c4d8208e7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ControllerInterface\XInput">
+      <UniqueIdentifier>{07bad1aa-7e03-4f5c-ade2-a44857c5cbc3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ControllerInterface\DualShockUDPClient">
+      <UniqueIdentifier>{ff02580e-3a62-4de4-a135-3a6c2c339a90}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="GCAdapter.cpp" />
+    <ClCompile Include="InputConfig.cpp" />
+    <ClCompile Include="ControllerEmu\ControllerEmu.cpp">
+      <Filter>ControllerEmu</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\StickGate.cpp">
+      <Filter>ControllerEmu</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\Control\Control.cpp">
+      <Filter>ControllerEmu\Control</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\Control\Input.cpp">
+      <Filter>ControllerEmu\Control</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\Control\Output.cpp">
+      <Filter>ControllerEmu\Control</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\ControlGroup\AnalogStick.cpp">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\ControlGroup\Buttons.cpp">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\ControlGroup\ControlGroup.cpp">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\ControlGroup\Cursor.cpp">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\ControlGroup\Force.cpp">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\ControlGroup\MixedTriggers.cpp">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\ControlGroup\ModifySettingsButton.cpp">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\ControlGroup\Slider.cpp">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\ControlGroup\Tilt.cpp">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\ControlGroup\Triggers.cpp">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\Setting\NumericSetting.cpp">
+      <Filter>ControllerEmu\Setting</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerInterface\DInput\DInput.cpp">
+      <Filter>ControllerInterface\DInput</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerInterface\DInput\DInputJoystick.cpp">
+      <Filter>ControllerInterface\DInput</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerInterface\DInput\DInputKeyboardMouse.cpp">
+      <Filter>ControllerInterface\DInput</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerInterface\XInput\XInput.cpp">
+      <Filter>ControllerInterface\XInput</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerInterface\Device.cpp">
+      <Filter>ControllerInterface</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerInterface\ControllerInterface.cpp">
+      <Filter>ControllerInterface</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerInterface\ForceFeedback\ForceFeedbackDevice.cpp">
+      <Filter>ControllerInterface\ForceFeedback</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerInterface\DInput\XInputFilter.cpp">
+      <Filter>ControllerInterface\DInput</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerInterface\Win32\Win32.cpp">
+      <Filter>ControllerInterface\Win32</Filter>
+    </ClCompile>
+    <ClCompile Include="ControlReference\ExpressionParser.cpp">
+      <Filter>ControllerInterface</Filter>
+    </ClCompile>
+    <ClCompile Include="ControlReference\ControlReference.cpp">
+      <Filter>ControllerInterface</Filter>
+    </ClCompile>
+    <ClCompile Include="ControlReference\FunctionExpression.cpp">
+      <Filter>ControllerInterface</Filter>
+    </ClCompile>
+    <ClCompile Include="InputProfile.cpp" />
+    <ClCompile Include="ControllerEmu\ControlGroup\Attachments.cpp">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\ControlGroup\IMUCursor.cpp">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\ControlGroup\IMUAccelerometer.cpp">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerEmu\ControlGroup\IMUGyroscope.cpp">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClCompile>
+    <ClCompile Include="ControllerInterface\DualShockUDPClient\DualShockUDPClient.cpp">
+      <Filter>ControllerInterface\DualShockUDPClient</Filter>
+    </ClCompile>
+    <ClCompile Include="DynamicInputTextureConfiguration.cpp" />
+    <ClCompile Include="DynamicInputTextureManager.cpp" />
+    <ClCompile Include="DInputMouseAbsolute.cpp" />
+    <ClCompile Include="ControllerInterface\Wiimote\Wiimote.cpp" />
+    <ClCompile Include="ControllerEmu\ControlGroup\PrimeHackModes.cpp" />
+    <ClCompile Include="GenericMouse.cpp" />
+    <ClCompile Include="ImageOperations.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="GCAdapter.h" />
+    <ClInclude Include="GCPadStatus.h" />
+    <ClInclude Include="InputConfig.h" />
+    <ClInclude Include="ControllerEmu\ControllerEmu.h">
+      <Filter>ControllerEmu</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\StickGate.h">
+      <Filter>ControllerEmu</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\Control\Control.h">
+      <Filter>ControllerEmu\Control</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\Control\Input.h">
+      <Filter>ControllerEmu\Control</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\Control\Output.h">
+      <Filter>ControllerEmu\Control</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\ControlGroup\AnalogStick.h">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\ControlGroup\Buttons.h">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\ControlGroup\ControlGroup.h">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\ControlGroup\Cursor.h">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\ControlGroup\Force.h">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\ControlGroup\MixedTriggers.h">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\ControlGroup\ModifySettingsButton.h">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\ControlGroup\Slider.h">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\ControlGroup\Tilt.h">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\ControlGroup\Triggers.h">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\Setting\NumericSetting.h">
+      <Filter>ControllerEmu\Setting</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerInterface\DInput\DInput.h">
+      <Filter>ControllerInterface\DInput</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerInterface\DInput\DInputJoystick.h">
+      <Filter>ControllerInterface\DInput</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerInterface\DInput\DInputKeyboardMouse.h">
+      <Filter>ControllerInterface\DInput</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerInterface\XInput\XInput.h">
+      <Filter>ControllerInterface\XInput</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerInterface\ControllerInterface.h">
+      <Filter>ControllerInterface</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerInterface\Device.h">
+      <Filter>ControllerInterface</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerInterface\ForceFeedback\ForceFeedbackDevice.h">
+      <Filter>ControllerInterface\ForceFeedback</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerInterface\DInput\DInput8.h">
+      <Filter>ControllerInterface\DInput</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerInterface\DInput\XInputFilter.h">
+      <Filter>ControllerInterface\DInput</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerInterface\Win32\Win32.h">
+      <Filter>ControllerInterface\Win32</Filter>
+    </ClInclude>
+    <ClInclude Include="ControlReference\ExpressionParser.h">
+      <Filter>ControllerInterface</Filter>
+    </ClInclude>
+    <ClInclude Include="ControlReference\ControlReference.h">
+      <Filter>ControllerInterface</Filter>
+    </ClInclude>
+    <ClInclude Include="InputProfile.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\Attachments.h">
+      <Filter>ControllerEmu\ControlGroup</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerEmu\ControlGroup\IMUAccelerometer.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\IMUCursor.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\IMUGyroscope.h" />
+    <ClInclude Include="ControllerInterface\DualShockUDPClient\DualShockUDPClient.h" />
+    <ClInclude Include="ControllerInterface\DualShockUDPClient\DualShockUDPProto.h" />
+    <ClInclude Include="ControlReference\FunctionExpression.h" />
+    <ClInclude Include="ControllerInterface\DualShockUDPClient\DualShockUDPClient.h">
+      <Filter>ControllerInterface\DualShockUDPClient</Filter>
+    </ClInclude>
+    <ClInclude Include="ControllerInterface\DualShockUDPClient\DualShockUDPProto.h">
+      <Filter>ControllerInterface\DualShockUDPClient</Filter>
+    </ClInclude>
+    <ClInclude Include="DynamicInputTextureConfiguration.h" />
+    <ClInclude Include="DynamicInputTextureManager.h" />
+    <ClInclude Include="DInputMouseAbsolute.h" />
+    <ClInclude Include="GenericMouse.h" />
+    <ClInclude Include="ControllerInterface\Wiimote\Wiimote.h" />
+    <ClInclude Include="ControllerEmu\ControlGroup\PrimeHackModes.h" />
+    <ClInclude Include="ImageOperations.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
+  </ItemGroup>
+</Project>

--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -196,6 +196,11 @@ void InputConfig::SaveConfig()
   inifile.Save(ini_filename);
 }
 
+void InputConfig::SetINIProfileName(std::string const& name)
+{
+  m_ini_profile_name = name;
+}
+
 ControllerEmu::EmulatedController* InputConfig::GetController(int index) const
 {
   return m_controllers.at(index).get();

--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -196,11 +196,6 @@ void InputConfig::SaveConfig()
   inifile.Save(ini_filename);
 }
 
-void InputConfig::SetINIProfileName(std::string const& name)
-{
-  m_ini_profile_name = name;
-}
-
 ControllerEmu::EmulatedController* InputConfig::GetController(int index) const
 {
   return m_controllers.at(index).get();

--- a/Source/Core/InputCommon/InputConfig.h
+++ b/Source/Core/InputCommon/InputConfig.h
@@ -48,7 +48,6 @@ public:
   std::string GetGUIName() const { return m_gui_name; }
   std::string GetProfileName() const { return m_profile_name; }
   int GetControllerCount() const;
-  void SetINIProfileName(std::string const& name);
 
   // These should be used after creating all controllers and before clearing them, respectively.
   void RegisterHotplugCallback();
@@ -62,6 +61,5 @@ private:
   const std::string m_ini_name;
   const std::string m_gui_name;
   const std::string m_profile_name;
-  std::string m_ini_profile_name;
   InputCommon::DynamicInputTextureManager m_dynamic_input_tex_config_manager;
 };

--- a/Source/Core/InputCommon/InputConfig.h
+++ b/Source/Core/InputCommon/InputConfig.h
@@ -20,7 +20,7 @@ class InputConfig
 {
 public:
   InputConfig(const std::string& ini_name, const std::string& gui_name,
-              const std::string& profile_name);
+    const std::string& profile_name);
 
   ~InputConfig();
 
@@ -47,7 +47,10 @@ public:
 
   std::string GetGUIName() const { return m_gui_name; }
   std::string GetProfileName() const { return m_profile_name; }
+  std::string GetININame() const { return m_ini_name; }
+  std::string GetINIProfileName() const { return m_ini_profile_name; }
   int GetControllerCount() const;
+  void SetINIProfileName(std::string const& name);
 
   // These should be used after creating all controllers and before clearing them, respectively.
   void RegisterHotplugCallback();
@@ -61,5 +64,6 @@ private:
   const std::string m_ini_name;
   const std::string m_gui_name;
   const std::string m_profile_name;
+  std::string m_ini_profile_name;
   InputCommon::DynamicInputTextureManager m_dynamic_input_tex_config_manager;
 };

--- a/Source/Core/InputCommon/InputConfig.h
+++ b/Source/Core/InputCommon/InputConfig.h
@@ -47,8 +47,6 @@ public:
 
   std::string GetGUIName() const { return m_gui_name; }
   std::string GetProfileName() const { return m_profile_name; }
-  std::string GetININame() const { return m_ini_name; }
-  std::string GetINIProfileName() const { return m_ini_profile_name; }
   int GetControllerCount() const;
   void SetINIProfileName(std::string const& name);
 

--- a/Source/Core/UICommon/UICommon.vcxproj
+++ b/Source/Core/UICommon/UICommon.vcxproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\VSProps\Base.Macros.props" />
+  <Import Project="$(VSPropsDir)Base.Targets.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{604C8368-F34A-4D55-82C8-CC92A0C13254}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VSPropsDir)Configuration.StaticLibrary.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VSPropsDir)Base.props" />
+    <Import Project="$(VSPropsDir)PCHUse.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CoreDir)Core\Core.vcxproj">
+      <Project>{E54CF649-140E-4255-81A5-30A673C1FB36}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)discord-rpc\src\discord-rpc.vcxproj">
+      <Project>{4482FD2A-EC43-3FFB-AC20-2E5C54B05EAD}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)picojson\picojson.vcxproj">
+      <Project>{2c0d058e-de35-4471-ad99-e68a2caf9e18}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)pugixml\pugixml.vcxproj">
+      <Project>{38fee76f-f347-484b-949c-b4649381cffb}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="AutoUpdate.cpp" />
+    <ClCompile Include="CommandLineParse.cpp" />
+    <ClCompile Include="DiscordPresence.cpp" />
+    <ClCompile Include="NetPlayIndex.cpp" />
+    <ClCompile Include="ResourcePack\Manager.cpp" />
+    <ClCompile Include="ResourcePack\Manifest.cpp" />
+    <ClCompile Include="ResourcePack\ResourcePack.cpp" />
+    <ClCompile Include="UICommon.cpp" />
+    <ClCompile Include="Disassembler.cpp" />
+    <ClCompile Include="USBUtils.cpp" />
+    <ClCompile Include="VideoUtils.cpp" />
+    <ClCompile Include="GameFile.cpp" />
+    <ClCompile Include="GameFileCache.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="AutoUpdate.h" />
+    <ClInclude Include="CommandLineParse.h" />
+    <ClInclude Include="DiscordPresence.h" />
+    <ClInclude Include="NetPlayIndex.h" />
+    <ClInclude Include="ResourcePack\Manager.h" />
+    <ClInclude Include="ResourcePack\Manifest.h" />
+    <ClInclude Include="ResourcePack\ResourcePack.h" />
+    <ClInclude Include="UICommon.h" />
+    <ClInclude Include="Disassembler.h" />
+    <ClInclude Include="USBUtils.h" />
+    <ClInclude Include="GameFile.h" />
+    <ClInclude Include="GameFileCache.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(ExternalsDir)cpp-optparse\cpp-optparse.vcxproj">
+      <Project>{C636D9D1-82FE-42B5-9987-63B7D4836341}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Core/UpdaterCommon/UpdaterCommon.vcxproj
+++ b/Source/Core/UpdaterCommon/UpdaterCommon.vcxproj
@@ -3,10 +3,10 @@
   <Import Project="..\..\VSProps\Base.Macros.props" />
   <Import Project="$(VSPropsDir)Base.Targets.props" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{E4BECBAB-9C6E-41AB-BB56-F9D70AB6BE03}</ProjectGuid>
+    <ProjectGuid>{B001D13E-7EAB-4689-842D-801E5ACFFAC5}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <Import Project="$(VSPropsDir)Configuration.Application.props" />
+  <Import Project="$(VSPropsDir)Configuration.StaticLibrary.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="PropertySheets">
@@ -15,29 +15,17 @@
     <Import Project="$(VSPropsDir)PCHUse.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup>
-    <TargetName>Updater</TargetName>
-  </PropertyGroup>
-  <ItemDefinitionGroup>
-    <Link>
-      <AdditionalDependencies>iphlpapi.lib;winmm.lib;ws2_32.lib;comctl32.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpplatest</LanguageStandard>
-    </ClCompile>
-    <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpplatest</LanguageStandard>
-    </ClCompile>
-    <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpplatest</LanguageStandard>
-    </ClCompile>
-    <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpplatest</LanguageStandard>
+      <PrecompiledHeader>Use</PrecompiledHeader>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ProjectReference Include="$(CoreDir)DolphinLib.vcxproj">
-      <Project>{D79392F7-06D6-4B4B-A39F-4D587C215D3A}</Project>
+    <ClCompile Include="UpdaterCommon.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CoreDir)Common\Common.vcxproj">
+      <Project>{2e6c348c-c75c-4d94-8d1e-9c1fcbf3efe4}</Project>
     </ProjectReference>
     <ProjectReference Include="$(ExternalsDir)cpp-optparse\cpp-optparse.vcxproj">
       <Project>{c636d9d1-82fe-42b5-9987-63b7d4836341}</Project>
@@ -55,23 +43,7 @@
       <Project>{ff213b23-2c26-4214-9f88-85271e557e87}</Project>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="..\UpdaterCommon\UpdaterCommon.cpp" />
-    <ClCompile Include="Main.cpp" />
-    <ClCompile Include="WinUI.cpp" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
-  <!--Copy the .exe to binary output folder-->
-  <ItemGroup>
-    <SourceFiles Include="$(TargetPath)" />
-  </ItemGroup>
-  <ItemGroup>
-    <Manifest Include="Updater.exe.manifest" />
-  </ItemGroup>
-  <Target Name="AfterBuild" Inputs="@(SourceFiles)" Outputs="@(SourceFiles -> '$(BinaryOutputDir)%(Filename)%(Extension)')">
-    <Message Text="Copy: @(SourceFiles) -&gt; $(BinaryOutputDir)" Importance="High" />
-    <Copy SourceFiles="@(SourceFiles)" DestinationFolder="$(BinaryOutputDir)" />
-  </Target>
 </Project>

--- a/Source/Core/VideoBackends/D3D/D3D.vcxproj
+++ b/Source/Core/VideoBackends/D3D/D3D.vcxproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\VSProps\Base.Macros.props" />
+  <Import Project="$(VSPropsDir)Base.Targets.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{96020103-4BA5-4FD2-B4AA-5B6D24492D4E}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VSPropsDir)Configuration.StaticLibrary.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VSPropsDir)Base.props" />
+    <Import Project="$(VSPropsDir)PCHUse.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="BoundingBox.cpp" />
+    <ClCompile Include="D3DBase.cpp" />
+    <ClCompile Include="D3DState.cpp" />
+    <ClCompile Include="DXPipeline.cpp" />
+    <ClCompile Include="DXShader.cpp" />
+    <ClCompile Include="DXTexture.cpp" />
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="NativeVertexFormat.cpp" />
+    <ClCompile Include="PerfQuery.cpp" />
+    <ClCompile Include="Render.cpp" />
+    <ClCompile Include="SwapChain.cpp" />
+    <ClCompile Include="VertexManager.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="BoundingBox.h" />
+    <ClInclude Include="D3DBase.h" />
+    <ClInclude Include="D3DState.h" />
+    <ClInclude Include="DXPipeline.h" />
+    <ClInclude Include="DXShader.h" />
+    <ClInclude Include="DXTexture.h" />
+    <ClInclude Include="PerfQuery.h" />
+    <ClInclude Include="Render.h" />
+    <ClInclude Include="SwapChain.h" />
+    <ClInclude Include="VertexManager.h" />
+    <ClInclude Include="VideoBackend.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CoreDir)VideoBackends\D3DCommon\D3DCommon.vcxproj">
+      <Project>{dea96cf2-f237-4a1a-b32f-c916769efb50}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(CoreDir)VideoCommon\VideoCommon.vcxproj">
+      <Project>{3de9ee35-3e91-4f27-a014-2866ad8c3fe3}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Core/VideoBackends/D3D12/D3D12.vcxproj
+++ b/Source/Core/VideoBackends/D3D12/D3D12.vcxproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\VSProps\Base.Macros.props" />
+  <Import Project="$(VSPropsDir)Base.Targets.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{570215B7-E32F-4438-95AE-C8D955F9FCA3}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VSPropsDir)Configuration.StaticLibrary.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VSPropsDir)Base.props" />
+    <Import Project="$(VSPropsDir)PCHUse.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="BoundingBox.cpp" />
+    <ClCompile Include="DescriptorAllocator.cpp" />
+    <ClCompile Include="DXContext.cpp" />
+    <ClCompile Include="DescriptorHeapManager.cpp" />
+    <ClCompile Include="DXPipeline.cpp" />
+    <ClCompile Include="DXShader.cpp" />
+    <ClCompile Include="StreamBuffer.cpp" />
+    <ClCompile Include="DXTexture.cpp" />
+    <ClCompile Include="VideoBackend.cpp" />
+    <ClCompile Include="PerfQuery.cpp" />
+    <ClCompile Include="Renderer.cpp" />
+    <ClCompile Include="DXVertexFormat.cpp" />
+    <ClCompile Include="SwapChain.cpp" />
+    <ClCompile Include="VertexManager.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="BoundingBox.h" />
+    <ClInclude Include="Common.h" />
+    <ClInclude Include="DescriptorAllocator.h" />
+    <ClInclude Include="DXContext.h" />
+    <ClInclude Include="DescriptorHeapManager.h" />
+    <ClInclude Include="DXPipeline.h" />
+    <ClInclude Include="DXShader.h" />
+    <ClInclude Include="StreamBuffer.h" />
+    <ClInclude Include="DXTexture.h" />
+    <ClInclude Include="PerfQuery.h" />
+    <ClInclude Include="Renderer.h" />
+    <ClInclude Include="DXVertexFormat.h" />
+    <ClInclude Include="SwapChain.h" />
+    <ClInclude Include="VertexManager.h" />
+    <ClInclude Include="VideoBackend.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CoreDir)VideoBackends\D3DCommon\D3DCommon.vcxproj">
+      <Project>{dea96cf2-f237-4a1a-b32f-c916769efb50}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(CoreDir)VideoCommon\VideoCommon.vcxproj">
+      <Project>{3de9ee35-3e91-4f27-a014-2866ad8c3fe3}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Core/VideoBackends/D3DCommon/D3DCommon.vcxproj
+++ b/Source/Core/VideoBackends/D3DCommon/D3DCommon.vcxproj
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\VSProps\Base.Macros.props" />
+  <Import Project="..\..\..\VSProps\Base.Macros.props" />
   <Import Project="$(VSPropsDir)Base.Targets.props" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{76563A7F-1011-4EAD-B667-7BB18D09568E}</ProjectGuid>
+    <ProjectGuid>{DEA96CF2-F237-4A1A-B32F-C916769EFB50}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(VSPropsDir)Configuration.StaticLibrary.props" />
@@ -12,34 +12,28 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(VSPropsDir)Base.props" />
-    <Import Project="$(VSPropsDir)PCHCreate.props" />
+    <Import Project="$(VSPropsDir)PCHUse.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <ClCompile>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <ClCompile>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <PrecompiledHeader>Use</PrecompiledHeader>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="pch.h" />
+    <ClCompile Include="Common.cpp" />
+    <ClCompile Include="Shader.cpp" />
+    <ClCompile Include="SwapChain.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="pch.cpp" />
+    <ClInclude Include="Common.h" />
+    <ClInclude Include="Shader.h" />
+    <ClInclude Include="SwapChain.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CoreDir)VideoCommon\VideoCommon.vcxproj">
+      <Project>{3de9ee35-3e91-4f27-a014-2866ad8c3fe3}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Source/Core/VideoBackends/Null/Null.vcxproj
+++ b/Source/Core/VideoBackends/Null/Null.vcxproj
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\VSProps\Base.Macros.props" />
+  <Import Project="..\..\..\VSProps\Base.Macros.props" />
   <Import Project="$(VSPropsDir)Base.Targets.props" />
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{76563A7F-1011-4EAD-B667-7BB18D09568E}</ProjectGuid>
+    <ProjectGuid>{53A5391B-737E-49A8-BC8F-312ADA00736F}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(VSPropsDir)Configuration.StaticLibrary.props" />
@@ -12,34 +12,35 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(VSPropsDir)Base.props" />
-    <Import Project="$(VSPropsDir)PCHCreate.props" />
+    <Import Project="$(VSPropsDir)PCHUse.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <ClCompile>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <ClCompile>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
-    </ClCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <PrecompiledHeader>Use</PrecompiledHeader>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="pch.h" />
+    <ClCompile Include="NullBackend.cpp" />
+    <ClCompile Include="NullTexture.cpp" />
+    <ClCompile Include="Render.cpp" />
+    <ClCompile Include="VertexManager.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="pch.cpp" />
+    <ClInclude Include="NullTexture.h" />
+    <ClInclude Include="PerfQuery.h" />
+    <ClInclude Include="Render.h" />
+    <ClInclude Include="TextureCache.h" />
+    <ClInclude Include="VertexManager.h" />
+    <ClInclude Include="VideoBackend.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CoreDir)VideoCommon\VideoCommon.vcxproj">
+      <Project>{3de9ee35-3e91-4f27-a014-2866ad8c3fe3}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Source/Core/VideoBackends/OGL/OGL.vcxproj
+++ b/Source/Core/VideoBackends/OGL/OGL.vcxproj
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\VSProps\Base.Macros.props" />
+  <Import Project="$(VSPropsDir)Base.Targets.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{EC1A314C-5588-4506-9C1E-2E58E5817F75}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VSPropsDir)Configuration.StaticLibrary.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VSPropsDir)Base.props" />
+    <Import Project="$(VSPropsDir)PCHUse.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="OGLPipeline.cpp" />
+    <ClCompile Include="OGLShader.cpp" />
+    <ClCompile Include="OGLTexture.cpp" />
+    <ClCompile Include="BoundingBox.cpp" />
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="NativeVertexFormat.cpp" />
+    <ClCompile Include="PerfQuery.cpp" />
+    <ClCompile Include="ProgramShaderCache.cpp" />
+    <ClCompile Include="Render.cpp" />
+    <ClCompile Include="SamplerCache.cpp" />
+    <ClCompile Include="StreamBuffer.cpp" />
+    <ClCompile Include="VertexManager.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="OGLPipeline.h" />
+    <ClInclude Include="OGLShader.h" />
+    <ClInclude Include="OGLTexture.h" />
+    <ClInclude Include="BoundingBox.h" />
+    <ClInclude Include="GPUTimer.h" />
+    <ClInclude Include="PerfQuery.h" />
+    <ClInclude Include="ProgramShaderCache.h" />
+    <ClInclude Include="Render.h" />
+    <ClInclude Include="SamplerCache.h" />
+    <ClInclude Include="StreamBuffer.h" />
+    <ClInclude Include="VertexManager.h" />
+    <ClInclude Include="VideoBackend.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CoreDir)VideoCommon\VideoCommon.vcxproj">
+      <Project>{3de9ee35-3e91-4f27-a014-2866ad8c3fe3}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)zlib\zlib.vcxproj">
+      <Project>{ff213b23-2c26-4214-9f88-85271e557e87}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Core/VideoBackends/Software/Software.vcxproj
+++ b/Source/Core/VideoBackends/Software/Software.vcxproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\VSProps\Base.Macros.props" />
+  <Import Project="$(VSPropsDir)Base.Targets.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A4C423AA-F57C-46C7-A172-D1A777017D29}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VSPropsDir)Configuration.StaticLibrary.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VSPropsDir)Base.props" />
+    <Import Project="$(VSPropsDir)PCHUse.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Clipper.cpp" />
+    <ClCompile Include="DebugUtil.cpp" />
+    <ClCompile Include="EfbCopy.cpp" />
+    <ClCompile Include="EfbInterface.cpp" />
+    <ClCompile Include="Rasterizer.cpp" />
+    <ClCompile Include="SetupUnit.cpp" />
+    <ClCompile Include="SWmain.cpp" />
+    <ClCompile Include="SWOGLWindow.cpp" />
+    <ClCompile Include="SWRenderer.cpp" />
+    <ClCompile Include="SWTexture.cpp" />
+    <ClCompile Include="SWVertexLoader.cpp" />
+    <ClCompile Include="Tev.cpp" />
+    <ClCompile Include="TextureEncoder.cpp" />
+    <ClCompile Include="TextureSampler.cpp" />
+    <ClCompile Include="TransformUnit.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Clipper.h" />
+    <ClInclude Include="CopyRegion.h" />
+    <ClInclude Include="DebugUtil.h" />
+    <ClInclude Include="EfbCopy.h" />
+    <ClInclude Include="EfbInterface.h" />
+    <ClInclude Include="NativeVertexFormat.h" />
+    <ClInclude Include="Rasterizer.h" />
+    <ClInclude Include="SetupUnit.h" />
+    <ClInclude Include="SWOGLWindow.h" />
+    <ClInclude Include="SWRenderer.h" />
+    <ClInclude Include="SWTexture.h" />
+    <ClInclude Include="SWVertexLoader.h" />
+    <ClInclude Include="Tev.h" />
+    <ClInclude Include="TextureCache.h" />
+    <ClInclude Include="TextureEncoder.h" />
+    <ClInclude Include="TextureSampler.h" />
+    <ClInclude Include="TransformUnit.h" />
+    <ClInclude Include="Vec3.h" />
+    <ClInclude Include="VideoBackend.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CoreDir)VideoCommon\VideoCommon.vcxproj">
+      <Project>{3de9ee35-3e91-4f27-a014-2866ad8c3fe3}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Core/VideoBackends/Vulkan/Vulkan.vcxproj
+++ b/Source/Core/VideoBackends/Vulkan/Vulkan.vcxproj
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\VSProps\Base.Macros.props" />
+  <Import Project="$(VSPropsDir)Base.Targets.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{29F29A19-F141-45AD-9679-5A2923B49DA3}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VSPropsDir)Configuration.StaticLibrary.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VSPropsDir)Base.props" />
+    <Import Project="$(VSPropsDir)PCHUse.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="BoundingBox.cpp" />
+    <ClCompile Include="CommandBufferManager.cpp" />
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="PerfQuery.cpp" />
+    <ClCompile Include="StagingBuffer.cpp" />
+    <ClCompile Include="VertexFormat.cpp" />
+    <ClCompile Include="ObjectCache.cpp" />
+    <ClCompile Include="Renderer.cpp" />
+    <ClCompile Include="ShaderCompiler.cpp" />
+    <ClCompile Include="StateTracker.cpp" />
+    <ClCompile Include="StreamBuffer.cpp" />
+    <ClCompile Include="SwapChain.cpp" />
+    <ClCompile Include="VertexManager.cpp" />
+    <ClCompile Include="VKPipeline.cpp" />
+    <ClCompile Include="VKShader.cpp" />
+    <ClCompile Include="VKTexture.cpp" />
+    <ClCompile Include="VulkanContext.cpp" />
+    <ClCompile Include="VulkanLoader.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="BoundingBox.h" />
+    <ClInclude Include="CommandBufferManager.h" />
+    <ClInclude Include="Constants.h" />
+    <ClInclude Include="StagingBuffer.h" />
+    <ClInclude Include="VertexFormat.h" />
+    <ClInclude Include="PerfQuery.h" />
+    <ClInclude Include="ObjectCache.h" />
+    <ClInclude Include="Renderer.h" />
+    <ClInclude Include="ShaderCompiler.h" />
+    <ClInclude Include="StateTracker.h" />
+    <ClInclude Include="StreamBuffer.h" />
+    <ClInclude Include="SwapChain.h" />
+    <ClInclude Include="VertexManager.h" />
+    <ClInclude Include="VideoBackend.h" />
+    <ClInclude Include="VKPipeline.h" />
+    <ClInclude Include="VKShader.h" />
+    <ClInclude Include="VKTexture.h" />
+    <ClInclude Include="VulkanContext.h" />
+    <ClInclude Include="VulkanLoader.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CoreDir)VideoCommon\VideoCommon.vcxproj">
+      <Project>{3de9ee35-3e91-4f27-a014-2866ad8c3fe3}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)glslang\glslang.vcxproj">
+      <Project>{d178061b-84d3-44f9-beed-efd18d9033f0}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="VulkanEntryPoints.inl" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj
@@ -1,0 +1,205 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\VSProps\Base.Macros.props" />
+  <Import Project="$(VSPropsDir)Base.Targets.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{3DE9EE35-3E91-4F27-A014-2866AD8C3FE3}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VSPropsDir)Configuration.StaticLibrary.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VSPropsDir)Base.props" />
+    <Import Project="$(VSPropsDir)PCHUse.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>HAS_OPENGL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>HAS_VULKAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Use</PrecompiledHeader>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="AbstractFramebuffer.cpp" />
+    <ClCompile Include="AbstractStagingTexture.cpp" />
+    <ClCompile Include="AbstractTexture.cpp" />
+    <ClCompile Include="AsyncRequests.cpp" />
+    <ClCompile Include="AsyncShaderCompiler.cpp" />
+    <ClCompile Include="FrameDump.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'=='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="BoundingBox.cpp" />
+    <ClCompile Include="BPFunctions.cpp" />
+    <ClCompile Include="BPMemory.cpp" />
+    <ClCompile Include="BPStructs.cpp" />
+    <ClCompile Include="CommandProcessor.cpp" />
+    <ClCompile Include="CPMemory.cpp" />
+    <ClCompile Include="DriverDetails.cpp" />
+    <ClCompile Include="Fifo.cpp" />
+    <ClCompile Include="FPSCounter.cpp" />
+    <ClCompile Include="FramebufferManager.cpp" />
+    <ClCompile Include="FramebufferShaderGen.cpp" />
+    <ClCompile Include="FreeLookCamera.cpp" />
+    <ClCompile Include="HiresTextures.cpp" />
+    <ClCompile Include="HiresTextures_DDSLoader.cpp" />
+    <ClCompile Include="ImageWrite.cpp" />
+    <ClCompile Include="IndexGenerator.cpp" />
+    <ClCompile Include="NetPlayChatUI.cpp" />
+    <ClCompile Include="NetPlayGolfUI.cpp" />
+    <ClCompile Include="OnScreenDisplay.cpp" />
+    <ClCompile Include="OpcodeDecoding.cpp" />
+    <ClCompile Include="PerfQueryBase.cpp" />
+    <ClCompile Include="PixelEngine.cpp" />
+    <ClCompile Include="PixelShaderGen.cpp" />
+    <ClCompile Include="PixelShaderManager.cpp" />
+    <ClCompile Include="PostProcessing.cpp" />
+    <ClCompile Include="RenderBase.cpp" />
+    <ClCompile Include="RenderState.cpp" />
+    <ClCompile Include="LightingShaderGen.cpp" />
+    <ClCompile Include="ShaderCache.cpp" />
+    <ClCompile Include="ShaderGenCommon.cpp" />
+    <ClCompile Include="TextureDecoder_Generic.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'=='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="UberShaderCommon.cpp" />
+    <ClCompile Include="UberShaderPixel.cpp" />
+    <ClCompile Include="Statistics.cpp" />
+    <ClCompile Include="GeometryShaderGen.cpp" />
+    <ClCompile Include="GeometryShaderManager.cpp" />
+    <ClCompile Include="TextureCacheBase.cpp" />
+    <ClCompile Include="TextureConfig.cpp" />
+    <ClCompile Include="TextureConversionShader.cpp" />
+    <ClCompile Include="TextureConverterShaderGen.cpp" />
+    <ClCompile Include="UberShaderVertex.cpp" />
+    <ClCompile Include="VertexLoader.cpp" />
+    <ClCompile Include="VertexLoaderARM64.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="VertexLoaderBase.cpp" />
+    <ClCompile Include="VertexLoaderX64.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="VertexLoaderManager.cpp" />
+    <ClCompile Include="VertexLoader_Color.cpp" />
+    <ClCompile Include="VertexLoader_Normal.cpp" />
+    <ClCompile Include="VertexLoader_Position.cpp" />
+    <ClCompile Include="VertexLoader_TextCoord.cpp" />
+    <ClCompile Include="VertexManagerBase.cpp" />
+    <ClCompile Include="VertexShaderGen.cpp" />
+    <ClCompile Include="VertexShaderManager.cpp" />
+    <ClCompile Include="VideoBackendBase.cpp" />
+    <ClCompile Include="VideoConfig.cpp" />
+    <ClCompile Include="VideoState.cpp" />
+    <ClCompile Include="TextureDecoder_Common.cpp" />
+    <ClCompile Include="TextureDecoder_x64.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="XFMemory.cpp" />
+    <ClCompile Include="XFStructs.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="AbstractFramebuffer.h" />
+    <ClInclude Include="AbstractStagingTexture.h" />
+    <ClInclude Include="AbstractPipeline.h" />
+    <ClInclude Include="AbstractShader.h" />
+    <ClInclude Include="AbstractTexture.h" />
+    <ClInclude Include="AsyncRequests.h" />
+    <ClInclude Include="AsyncShaderCompiler.h" />
+    <ClInclude Include="FrameDump.h" />
+    <ClInclude Include="BoundingBox.h" />
+    <ClInclude Include="BPFunctions.h" />
+    <ClInclude Include="BPMemory.h" />
+    <ClInclude Include="BPStructs.h" />
+    <ClInclude Include="CommandProcessor.h" />
+    <ClInclude Include="CPMemory.h" />
+    <ClInclude Include="DataReader.h" />
+    <ClInclude Include="DriverDetails.h" />
+    <ClInclude Include="Fifo.h" />
+    <ClInclude Include="FPSCounter.h" />
+    <ClInclude Include="FramebufferManager.h" />
+    <ClInclude Include="FramebufferShaderGen.h" />
+    <ClInclude Include="FreeLookCamera.h" />
+    <ClInclude Include="GXPipelineTypes.h" />
+    <ClInclude Include="NetPlayChatUI.h" />
+    <ClInclude Include="NetPlayGolfUI.h" />
+    <ClInclude Include="ShaderCache.h" />
+    <ClInclude Include="UberShaderCommon.h" />
+    <ClInclude Include="UberShaderPixel.h" />
+    <ClInclude Include="HiresTextures.h" />
+    <ClInclude Include="ImageWrite.h" />
+    <ClInclude Include="IndexGenerator.h" />
+    <ClInclude Include="LightingShaderGen.h" />
+    <ClInclude Include="LookUpTables.h" />
+    <ClInclude Include="NativeVertexFormat.h" />
+    <ClInclude Include="OnScreenDisplay.h" />
+    <ClInclude Include="OpcodeDecoding.h" />
+    <ClInclude Include="PerfQueryBase.h" />
+    <ClInclude Include="PixelEngine.h" />
+    <ClInclude Include="PixelShaderGen.h" />
+    <ClInclude Include="PixelShaderManager.h" />
+    <ClInclude Include="PostProcessing.h" />
+    <ClInclude Include="RenderBase.h" />
+    <ClInclude Include="RenderState.h" />
+    <ClInclude Include="SamplerCommon.h" />
+    <ClInclude Include="ShaderGenCommon.h" />
+    <ClInclude Include="Statistics.h" />
+    <ClInclude Include="GeometryShaderGen.h" />
+    <ClInclude Include="GeometryShaderManager.h" />
+    <ClInclude Include="TextureCacheBase.h" />
+    <ClInclude Include="TextureConfig.h" />
+    <ClInclude Include="TextureConversionShader.h" />
+    <ClInclude Include="TextureConverterShaderGen.h" />
+    <ClInclude Include="TextureDecoder.h" />
+    <ClInclude Include="UberShaderVertex.h" />
+    <ClInclude Include="VertexLoader.h" />
+    <ClInclude Include="VertexLoaderARM64.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='ARM64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="VertexLoaderBase.h" />
+    <ClInclude Include="VertexLoaderManager.h" />
+    <ClInclude Include="VertexLoaderUtils.h" />
+    <ClInclude Include="VertexLoader_Color.h" />
+    <ClInclude Include="VertexLoader_Normal.h" />
+    <ClInclude Include="VertexLoader_Position.h" />
+    <ClInclude Include="VertexLoader_TextCoord.h" />
+    <ClInclude Include="VertexManagerBase.h" />
+    <ClInclude Include="VertexShaderGen.h" />
+    <ClInclude Include="VertexShaderManager.h" />
+    <ClInclude Include="VideoBackendBase.h" />
+    <ClInclude Include="VideoCommon.h" />
+    <ClInclude Include="VideoConfig.h" />
+    <ClInclude Include="VideoState.h" />
+    <ClInclude Include="XFMemory.h" />
+    <ClInclude Include="XFStructs.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(CoreDir)Common\Common.vcxproj">
+      <Project>{2e6c348c-c75c-4d94-8d1e-9c1fcbf3efe4}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)imgui\imgui.vcxproj">
+      <Project>{4c3b2264-ea73-4a7b-9cfe-65b0fd635ebb}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)libpng\png\png.vcxproj">
+      <Project>{4c9f135b-a85e-430c-bad4-4c67ef5fc12c}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)xxhash\xxhash.vcxproj">
+      <Project>{677EA016-1182-440C-9345-DC88D1E98C0C}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(ExternalsDir)zlib\zlib.vcxproj">
+      <Project>{ff213b23-2c26-4214-9f88-85271e557e87}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj.filters
@@ -1,0 +1,416 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Base">
+      <UniqueIdentifier>{23908fac-d3fd-4fa5-a9b4-87b3bafc7bd9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Decoding">
+      <UniqueIdentifier>{2baa29c2-a528-4981-abcb-e0842c311f63}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Register Sections">
+      <UniqueIdentifier>{6a88e4a0-754c-43df-98e6-405c99cd2ca7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Shader Generators">
+      <UniqueIdentifier>{7ce5076f-4e85-4f4d-b3f0-8c88267b8b2d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Shader Managers">
+      <UniqueIdentifier>{8c17624b-2ccb-4ee4-9ec0-593f8f3d1dd2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Util">
+      <UniqueIdentifier>{8edd4982-cce6-406e-9029-f7a6449311b1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Vertex Loading">
+      <UniqueIdentifier>{cefc166b-1f5e-4e96-863d-1448e14c0741}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="CommandProcessor.cpp" />
+    <ClCompile Include="DriverDetails.cpp" />
+    <ClCompile Include="PixelEngine.cpp" />
+    <ClCompile Include="VideoBackendBase.cpp" />
+    <ClCompile Include="VideoConfig.cpp" />
+    <ClCompile Include="PerfQueryBase.cpp">
+      <Filter>Base</Filter>
+    </ClCompile>
+    <ClCompile Include="RenderBase.cpp">
+      <Filter>Base</Filter>
+    </ClCompile>
+    <ClCompile Include="RenderState.cpp">
+      <Filter>Base</Filter>
+    </ClCompile>
+    <ClCompile Include="TextureCacheBase.cpp">
+      <Filter>Base</Filter>
+    </ClCompile>
+    <ClCompile Include="VertexManagerBase.cpp">
+      <Filter>Base</Filter>
+    </ClCompile>
+    <ClCompile Include="Fifo.cpp">
+      <Filter>Decoding</Filter>
+    </ClCompile>
+    <ClCompile Include="OpcodeDecoding.cpp">
+      <Filter>Decoding</Filter>
+    </ClCompile>
+    <ClCompile Include="BPFunctions.cpp">
+      <Filter>Register Sections</Filter>
+    </ClCompile>
+    <ClCompile Include="BPMemory.cpp">
+      <Filter>Register Sections</Filter>
+    </ClCompile>
+    <ClCompile Include="BPStructs.cpp">
+      <Filter>Register Sections</Filter>
+    </ClCompile>
+    <ClCompile Include="CPMemory.cpp">
+      <Filter>Register Sections</Filter>
+    </ClCompile>
+    <ClCompile Include="XFMemory.cpp">
+      <Filter>Register Sections</Filter>
+    </ClCompile>
+    <ClCompile Include="XFStructs.cpp">
+      <Filter>Register Sections</Filter>
+    </ClCompile>
+    <ClCompile Include="PixelShaderGen.cpp">
+      <Filter>Shader Generators</Filter>
+    </ClCompile>
+    <ClCompile Include="TextureConversionShader.cpp">
+      <Filter>Shader Generators</Filter>
+    </ClCompile>
+    <ClCompile Include="TextureConverterShaderGen.cpp">
+      <Filter>Shader Generators</Filter>
+    </ClCompile>
+    <ClCompile Include="VertexShaderGen.cpp">
+      <Filter>Shader Generators</Filter>
+    </ClCompile>
+    <ClCompile Include="PixelShaderManager.cpp">
+      <Filter>Shader Managers</Filter>
+    </ClCompile>
+    <ClCompile Include="VertexShaderManager.cpp">
+      <Filter>Shader Managers</Filter>
+    </ClCompile>
+    <ClCompile Include="FrameDump.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
+    <ClCompile Include="FPSCounter.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
+    <ClCompile Include="HiresTextures.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
+    <ClCompile Include="ImageWrite.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
+    <ClCompile Include="IndexGenerator.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
+    <ClCompile Include="OnScreenDisplay.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
+    <ClCompile Include="PostProcessing.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
+    <ClCompile Include="Statistics.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
+    <ClCompile Include="VideoState.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
+    <ClCompile Include="VertexLoader.cpp">
+      <Filter>Vertex Loading</Filter>
+    </ClCompile>
+    <ClCompile Include="VertexLoaderBase.cpp">
+      <Filter>Vertex Loading</Filter>
+    </ClCompile>
+    <ClCompile Include="VertexLoaderX64.cpp">
+      <Filter>Vertex Loading</Filter>
+    </ClCompile>
+    <ClCompile Include="VertexLoader_Color.cpp">
+      <Filter>Vertex Loading</Filter>
+    </ClCompile>
+    <ClCompile Include="VertexLoader_Normal.cpp">
+      <Filter>Vertex Loading</Filter>
+    </ClCompile>
+    <ClCompile Include="VertexLoader_Position.cpp">
+      <Filter>Vertex Loading</Filter>
+    </ClCompile>
+    <ClCompile Include="VertexLoader_TextCoord.cpp">
+      <Filter>Vertex Loading</Filter>
+    </ClCompile>
+    <ClCompile Include="VertexLoaderManager.cpp">
+      <Filter>Vertex Loading</Filter>
+    </ClCompile>
+    <ClCompile Include="TextureDecoder_Common.cpp">
+      <Filter>Decoding</Filter>
+    </ClCompile>
+    <ClCompile Include="TextureDecoder_x64.cpp">
+      <Filter>Decoding</Filter>
+    </ClCompile>
+    <ClCompile Include="AsyncRequests.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
+    <ClCompile Include="BoundingBox.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
+    <ClCompile Include="GeometryShaderGen.cpp">
+      <Filter>Shader Generators</Filter>
+    </ClCompile>
+    <ClCompile Include="GeometryShaderManager.cpp">
+      <Filter>Shader Managers</Filter>
+    </ClCompile>
+    <ClCompile Include="LightingShaderGen.cpp">
+      <Filter>Shader Generators</Filter>
+    </ClCompile>
+    <ClCompile Include="HiresTextures_DDSLoader.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
+    <ClCompile Include="TextureConfig.cpp">
+      <Filter>Base</Filter>
+    </ClCompile>
+    <ClCompile Include="AbstractTexture.cpp">
+      <Filter>Base</Filter>
+    </ClCompile>
+    <ClCompile Include="ShaderGenCommon.cpp">
+      <Filter>Shader Generators</Filter>
+    </ClCompile>
+    <ClCompile Include="AsyncShaderCompiler.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
+    <ClCompile Include="UberShaderPixel.cpp">
+      <Filter>Shader Generators</Filter>
+    </ClCompile>
+    <ClCompile Include="UberShaderCommon.cpp">
+      <Filter>Shader Generators</Filter>
+    </ClCompile>
+    <ClCompile Include="UberShaderVertex.cpp">
+      <Filter>Shader Generators</Filter>
+    </ClCompile>
+    <ClCompile Include="AbstractStagingTexture.cpp">
+      <Filter>Base</Filter>
+    </ClCompile>
+    <ClCompile Include="AbstractFramebuffer.cpp">
+      <Filter>Base</Filter>
+    </ClCompile>
+    <ClCompile Include="ShaderCache.cpp">
+      <Filter>Shader Generators</Filter>
+    </ClCompile>
+    <ClCompile Include="FramebufferShaderGen.cpp">
+      <Filter>Shader Generators</Filter>
+    </ClCompile>
+    <ClCompile Include="FramebufferManager.cpp">
+      <Filter>Base</Filter>
+    </ClCompile>
+    <ClCompile Include="NetPlayChatUI.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
+    <ClCompile Include="NetPlayGolfUI.cpp">
+      <Filter>Util</Filter>
+    </ClCompile>
+    <ClCompile Include="TextureDecoder_Generic.cpp">
+      <Filter>Decoding</Filter>
+    </ClCompile>
+    <ClCompile Include="VertexLoaderARM64.cpp">
+      <Filter>Vertex Loading</Filter>
+    </ClCompile>
+    <ClCompile Include="FreeLookCamera.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="CommandProcessor.h" />
+    <ClInclude Include="DriverDetails.h" />
+    <ClInclude Include="NativeVertexFormat.h" />
+    <ClInclude Include="PixelEngine.h" />
+    <ClInclude Include="VideoBackendBase.h" />
+    <ClInclude Include="VideoCommon.h" />
+    <ClInclude Include="VideoConfig.h" />
+    <ClInclude Include="PerfQueryBase.h">
+      <Filter>Base</Filter>
+    </ClInclude>
+    <ClInclude Include="RenderBase.h">
+      <Filter>Base</Filter>
+    </ClInclude>
+    <ClInclude Include="RenderState.h">
+      <Filter>Base</Filter>
+    </ClInclude>
+    <ClInclude Include="TextureCacheBase.h">
+      <Filter>Base</Filter>
+    </ClInclude>
+    <ClInclude Include="VertexManagerBase.h">
+      <Filter>Base</Filter>
+    </ClInclude>
+    <ClInclude Include="Fifo.h">
+      <Filter>Decoding</Filter>
+    </ClInclude>
+    <ClInclude Include="OpcodeDecoding.h">
+      <Filter>Decoding</Filter>
+    </ClInclude>
+    <ClInclude Include="TextureDecoder.h">
+      <Filter>Decoding</Filter>
+    </ClInclude>
+    <ClInclude Include="BPFunctions.h">
+      <Filter>Register Sections</Filter>
+    </ClInclude>
+    <ClInclude Include="BPMemory.h">
+      <Filter>Register Sections</Filter>
+    </ClInclude>
+    <ClInclude Include="BPStructs.h">
+      <Filter>Register Sections</Filter>
+    </ClInclude>
+    <ClInclude Include="CPMemory.h">
+      <Filter>Register Sections</Filter>
+    </ClInclude>
+    <ClInclude Include="XFMemory.h">
+      <Filter>Register Sections</Filter>
+    </ClInclude>
+    <ClInclude Include="XFStructs.h">
+      <Filter>Register Sections</Filter>
+    </ClInclude>
+    <ClInclude Include="LightingShaderGen.h">
+      <Filter>Shader Generators</Filter>
+    </ClInclude>
+    <ClInclude Include="PixelShaderGen.h">
+      <Filter>Shader Generators</Filter>
+    </ClInclude>
+    <ClInclude Include="ShaderGenCommon.h">
+      <Filter>Shader Generators</Filter>
+    </ClInclude>
+    <ClInclude Include="TextureConversionShader.h">
+      <Filter>Shader Generators</Filter>
+    </ClInclude>
+    <ClInclude Include="VertexShaderGen.h">
+      <Filter>Shader Generators</Filter>
+    </ClInclude>
+    <ClInclude Include="PixelShaderManager.h">
+      <Filter>Shader Managers</Filter>
+    </ClInclude>
+    <ClInclude Include="VertexShaderManager.h">
+      <Filter>Shader Managers</Filter>
+    </ClInclude>
+    <ClInclude Include="FrameDump.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="FPSCounter.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="HiresTextures.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="ImageWrite.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="IndexGenerator.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="LookUpTables.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="OnScreenDisplay.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="PostProcessing.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="Statistics.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="VideoState.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="DataReader.h">
+      <Filter>Vertex Loading</Filter>
+    </ClInclude>
+    <ClInclude Include="VertexLoader.h">
+      <Filter>Vertex Loading</Filter>
+    </ClInclude>
+    <ClInclude Include="VertexLoaderBase.h">
+      <Filter>Vertex Loading</Filter>
+    </ClInclude>
+    <ClInclude Include="VertexLoader_Color.h">
+      <Filter>Vertex Loading</Filter>
+    </ClInclude>
+    <ClInclude Include="VertexLoader_Normal.h">
+      <Filter>Vertex Loading</Filter>
+    </ClInclude>
+    <ClInclude Include="VertexLoader_Position.h">
+      <Filter>Vertex Loading</Filter>
+    </ClInclude>
+    <ClInclude Include="VertexLoader_TextCoord.h">
+      <Filter>Vertex Loading</Filter>
+    </ClInclude>
+    <ClInclude Include="VertexLoaderManager.h">
+      <Filter>Vertex Loading</Filter>
+    </ClInclude>
+    <ClInclude Include="VertexLoaderUtils.h">
+      <Filter>Vertex Loading</Filter>
+    </ClInclude>
+    <ClInclude Include="AsyncRequests.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="BoundingBox.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="GeometryShaderGen.h">
+      <Filter>Shader Generators</Filter>
+    </ClInclude>
+    <ClInclude Include="GeometryShaderManager.h">
+      <Filter>Shader Managers</Filter>
+    </ClInclude>
+    <ClInclude Include="SamplerCommon.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="TextureConfig.h">
+      <Filter>Base</Filter>
+    </ClInclude>
+    <ClInclude Include="AbstractTexture.h">
+      <Filter>Base</Filter>
+    </ClInclude>
+    <ClInclude Include="AsyncShaderCompiler.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="UberShaderPixel.h">
+      <Filter>Shader Generators</Filter>
+    </ClInclude>
+    <ClInclude Include="UberShaderCommon.h">
+      <Filter>Shader Generators</Filter>
+    </ClInclude>
+    <ClInclude Include="UberShaderVertex.h">
+      <Filter>Shader Generators</Filter>
+    </ClInclude>
+    <ClInclude Include="AbstractStagingTexture.h">
+      <Filter>Base</Filter>
+    </ClInclude>
+    <ClInclude Include="AbstractShader.h">
+      <Filter>Base</Filter>
+    </ClInclude>
+    <ClInclude Include="AbstractPipeline.h">
+      <Filter>Base</Filter>
+    </ClInclude>
+    <ClInclude Include="AbstractFramebuffer.h">
+      <Filter>Base</Filter>
+    </ClInclude>
+    <ClInclude Include="GXPipelineTypes.h">
+      <Filter>Shader Generators</Filter>
+    </ClInclude>
+    <ClInclude Include="ShaderCache.h">
+      <Filter>Shader Generators</Filter>
+    </ClInclude>
+    <ClInclude Include="FramebufferShaderGen.h">
+      <Filter>Shader Generators</Filter>
+    </ClInclude>
+    <ClInclude Include="FramebufferManager.h">
+      <Filter>Base</Filter>
+    </ClInclude>
+    <ClInclude Include="TextureConverterShaderGen.h">
+      <Filter>Shader Generators</Filter>
+    </ClInclude>
+    <ClInclude Include="NetPlayChatUI.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="NetPlayGolfUI.h">
+      <Filter>Util</Filter>
+    </ClInclude>
+    <ClInclude Include="VertexLoaderARM64.h">
+      <Filter>Vertex Loading</Filter>
+    </ClInclude>
+    <ClInclude Include="FreeLookCamera.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="CMakeLists.txt" />
+  </ItemGroup>
+</Project>

--- a/Source/Core/WinUpdater/WinUpdater.vcxproj
+++ b/Source/Core/WinUpdater/WinUpdater.vcxproj
@@ -23,7 +23,16 @@
       <AdditionalDependencies>iphlpapi.lib;winmm.lib;ws2_32.lib;comctl32.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp20</LanguageStandard>
+    </ClCompile>
+    <ClCompile>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpp20</LanguageStandard>
+    </ClCompile>
+    <ClCompile>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpp20</LanguageStandard>
+    </ClCompile>
+    <ClCompile>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/DSPTool/DSPTool.vcxproj
+++ b/Source/DSPTool/DSPTool.vcxproj
@@ -21,7 +21,16 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp20</LanguageStandard>
+    </ClCompile>
+    <ClCompile>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpp20</LanguageStandard>
+    </ClCompile>
+    <ClCompile>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpp20</LanguageStandard>
+    </ClCompile>
+    <ClCompile>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/DSPTool/DSPTool.vcxproj
+++ b/Source/DSPTool/DSPTool.vcxproj
@@ -21,16 +21,16 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpplatest</LanguageStandard>
     </ClCompile>
     <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpplatest</LanguageStandard>
     </ClCompile>
     <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpplatest</LanguageStandard>
     </ClCompile>
     <ClCompile>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpplatest</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/PCH/pch.vcxproj
+++ b/Source/PCH/pch.vcxproj
@@ -17,7 +17,22 @@
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/UnitTests/UnitTests.vcxproj
+++ b/Source/UnitTests/UnitTests.vcxproj
@@ -19,10 +19,10 @@
     <!--This project also compiles gtest-->
     <ClCompile>
       <AdditionalIncludeDirectories>$(ExternalsDir)gtest\include;$(ExternalsDir)gtest;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp20</LanguageStandard>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpp20</LanguageStandard>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpp20</LanguageStandard>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <!--

--- a/Source/UnitTests/UnitTests.vcxproj
+++ b/Source/UnitTests/UnitTests.vcxproj
@@ -19,7 +19,10 @@
     <!--This project also compiles gtest-->
     <ClCompile>
       <AdditionalIncludeDirectories>$(ExternalsDir)gtest\include;$(ExternalsDir)gtest;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <!--


### PR DESCRIPTION
Adds a profile selector for the morphball.  Users make a custom profile using the normal method for the morphball first.  Save it, then close the window to reload profiles.  Then re-enter and make/load their main profile, then pick the profile they made for the morphball in the "Morphball Controller Profile".  Save their main profile and it should add it to their main profile.

Once added, in-game upon entering morphball, primehack will automatically switch the profile to the morphball profile for a seperate set of controls.  When exiting morphball, primehack will swap back to the original controller profile the user had loaded before.

If users want to disable this feature, then erase the profile text in "Morphball Controller Profile" and the re-save your main profile.  Dolphin will detect that the field was saved empty, and not use a separate profile for morphball in-game, instead staying on the main profile.