### PR TITLE
Add Feature For Morphball Profiles for Metroid Prime 3

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -344,8 +344,6 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
   m_primehack_visors->AddSetting(
     &m_primehack_visor_menu, {"Enable Visor Menu", nullptr, nullptr, _trans("Enable Visor Menu")}, false);
 
-  // PrimeHack Morphball Controls
-  // Menu options for this Group are stored in the WiimoteEmu files (WiimoteEmuMetroid.cpp, PrimeHackEmuWii.cpp, etc.)
   groups.emplace_back(m_primehack_morphball_controls = new ControllerEmu::PrimeHackMorph(_trans("PrimeHack"), ""));
 
   groups.emplace_back(m_primehack_camera = new ControllerEmu::ControlGroup(_trans("PrimeHack")));

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -39,6 +39,7 @@
 #include "InputCommon/ControllerEmu/Control/Output.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Attachments.h"
 #include "InputCommon/ControllerEmu/ControlGroup/PrimeHackModes.h"
+#include "InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Cursor.h"
@@ -343,6 +344,10 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index)
   m_primehack_visors->AddSetting(
     &m_primehack_visor_menu, {"Enable Visor Menu", nullptr, nullptr, _trans("Enable Visor Menu")}, false);
 
+  // PrimeHack Morphball Controls
+  // Menu options for this Group are stored in the WiimoteEmu files (WiimoteEmuMetroid.cpp, PrimeHackEmuWii.cpp, etc.)
+  groups.emplace_back(m_primehack_morphball_controls = new ControllerEmu::PrimeHackMorph(_trans("PrimeHack"), ""));
+
   groups.emplace_back(m_primehack_camera = new ControllerEmu::ControlGroup(_trans("PrimeHack")));
 
   m_primehack_camera->AddSetting(
@@ -475,6 +480,8 @@ ControllerEmu::ControlGroup* Wiimote::GetWiimoteGroup(WiimoteGroup group) const
     return m_primehack_stick;
   case WiimoteGroup::Modes:
     return m_primehack_modes;
+  case WiimoteGroup::MorphballControls:
+    return m_primehack_morphball_controls;
   default:
     ASSERT(false);
     return nullptr;

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -24,6 +24,7 @@ namespace ControllerEmu
 {
 class Attachments;
 class PrimeHackModes;
+class PrimeHackMorph;
 class Buttons;
 class ControlGroup;
 class Cursor;
@@ -61,7 +62,8 @@ enum class WiimoteGroup
   Camera,
   Misc,
   ControlStick,
-  Modes
+  Modes,
+  MorphballControls
 };
 
 enum class NunchukGroup;
@@ -294,6 +296,7 @@ private:
   ControllerEmu::ControlGroup* m_primehack_motionhacks;
   ControllerEmu::ControlGroup* m_primehack_camera;
   ControllerEmu::ControlGroup* m_primehack_misc;
+  ControllerEmu::PrimeHackMorph* m_primehack_morphball_controls;
   ControllerEmu::PrimeHackModes* m_primehack_modes;
   ControllerEmu::AnalogStick* m_primehack_stick;
 

--- a/Source/Core/Core/PrimeHack/HackConfig.cpp
+++ b/Source/Core/Core/PrimeHack/HackConfig.cpp
@@ -268,7 +268,6 @@ std::pair<std::string, std::string> getProfiles()
 
   //Make sure we get the full path
   const std::string morph_profname = group->GetMorphBallProfileName();
-  const std::string main_profname = group->GetMainProfileName();
   std::string morph_profile_path;
   std::string main_profile_path;
 

--- a/Source/Core/Core/PrimeHack/HackConfig.cpp
+++ b/Source/Core/Core/PrimeHack/HackConfig.cpp
@@ -260,26 +260,20 @@ std::tuple<float, float, float> GetArmXYZ() {
   return std::make_tuple(x, y, z);
 }
 
-// First is morphball profile, Second is main controller profile
-std::pair<std::string, std::string> getProfiles()
-{
+
+std::pair<std::string, std::string> GetProfiles() {
   auto* group = static_cast<ControllerEmu::PrimeHackMorph*>(
     Wiimote::GetWiimoteGroup(0, WiimoteEmu::WiimoteGroup::MorphballControls));
 
-  //Make sure we get the full path
   const std::string morph_profname = group->GetMorphBallProfileName();
   std::string morph_profile_path;
   std::string main_profile_path;
 
-  //Prevent any goofiness...
-  if (!morph_profname.empty() && (morph_profname != std::string("None")))
-  {
+  if (!morph_profname.empty() && (morph_profname != std::string("None"))) {
     morph_profile_path = File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR +
       Wiimote::GetConfig()->GetProfileName() + "/" + group->GetMorphBallProfileName() +
       ".ini";
-  }
-  else
-  {
+  } else {
     morph_profile_path = "";
   }
 
@@ -293,19 +287,10 @@ void ChangeControllerProfileMorphBall(std::string profile_path)
   IniFile ini;
   ini.Load(profile_path);
 
-  //Hacky way to figure out if we're loading from backup controller state or loading a real profile
-  IniFile::Section* section = ini.GetSection("Wiimote1");
+  std::string profile_name = ini.GetSection("Wiimote1") ? "Wiimote1" : "Profile";
 
-  if (section)
-  {
-    Wiimote::GetConfig()->GetController(0)->LoadConfig(ini.GetOrCreateSection("Wiimote1"));
-    Wiimote::GetConfig()->GetController(0)->UpdateReferences(g_controller_interface);
-  }
-  else
-  {
-    Wiimote::GetConfig()->GetController(0)->LoadConfig(ini.GetOrCreateSection("Profile"));
-    Wiimote::GetConfig()->GetController(0)->UpdateReferences(g_controller_interface);
-  }
+  Wiimote::GetConfig()->GetController(0)->LoadConfig(ini.GetOrCreateSection(profile_name));
+  Wiimote::GetConfig()->GetController(0)->UpdateReferences(g_controller_interface);
 }
 
 void UpdateHackSettings() {

--- a/Source/Core/Core/PrimeHack/HackConfig.cpp
+++ b/Source/Core/Core/PrimeHack/HackConfig.cpp
@@ -269,7 +269,7 @@ std::pair<std::string, std::string> GetProfiles() {
   std::string morph_profile_path;
   std::string main_profile_path;
 
-  if (!morph_profname.empty() && (morph_profname != std::string("None"))) {
+  if (!morph_profname.empty() && (morph_profname != std::string("Disabled"))) {
     morph_profile_path = File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR +
       Wiimote::GetConfig()->GetProfileName() + "/" + group->GetMorphBallProfileName() +
       ".ini";

--- a/Source/Core/Core/PrimeHack/HackConfig.cpp
+++ b/Source/Core/Core/PrimeHack/HackConfig.cpp
@@ -4,6 +4,11 @@
 #include <string>
 
 #include "Common/IniFile.h"
+#include "Common/CommonPaths.h"
+#include "Common/FileSearch.h"
+#include "Common/FileUtil.h"
+#include "Common/IniFile.h"
+#include "Common/StringUtil.h"
 
 #include "Core/PrimeHack/PrimeUtils.h"
 #include "Core/PrimeHack/EmuVariableManager.h"
@@ -33,9 +38,13 @@
 #include "Core/Config/GraphicsSettings.h"
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
+#include "InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h"
+#include "InputCommon/InputConfig.h"
 
 #include "VideoCommon/VideoConfig.h"
 #include <Core/Host.h>
+
+constexpr const char* PROFILES_DIR = "Profiles/";
 
 namespace prime {
 namespace {
@@ -249,6 +258,55 @@ std::tuple<float, float, float> GetArmXYZ() {
   float z = Config::Get(Config::ARMPOSITION_UPDOWN) / 100.f;
 
   return std::make_tuple(x, y, z);
+}
+
+// First is morphball profile, Second is main controller profile
+std::pair<std::string, std::string> getProfiles()
+{
+  auto* group = static_cast<ControllerEmu::PrimeHackMorph*>(
+    Wiimote::GetWiimoteGroup(0, WiimoteEmu::WiimoteGroup::MorphballControls));
+
+  //Make sure we get the full path
+  const std::string morph_profname = group->GetMorphBallProfileName();
+  const std::string main_profname = group->GetMainProfileName();
+  std::string morph_profile_path;
+  std::string main_profile_path;
+
+  //Prevent any goofiness...
+  if (!morph_profname.empty() && (morph_profname != std::string("None")))
+  {
+    morph_profile_path = File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR +
+      Wiimote::GetConfig()->GetProfileName() + "/" + group->GetMorphBallProfileName() +
+      ".ini";
+  }
+  else
+  {
+    morph_profile_path = "";
+  }
+
+  main_profile_path = File::GetUserPath(D_CONFIG_IDX) + WIIMOTE_INI_NAME + "_Backup.ini";
+
+  return { morph_profile_path, main_profile_path };
+}
+
+void ChangeControllerProfileMorphBall(std::string profile_path)
+{
+  IniFile ini;
+  ini.Load(profile_path);
+
+  //Hacky way to figure out if we're loading from backup controller state or loading a real profile
+  IniFile::Section* section = ini.GetSection("Wiimote1");
+
+  if (section)
+  {
+    Wiimote::GetConfig()->GetController(0)->LoadConfig(ini.GetOrCreateSection("Wiimote1"));
+    Wiimote::GetConfig()->GetController(0)->UpdateReferences(g_controller_interface);
+  }
+  else
+  {
+    Wiimote::GetConfig()->GetController(0)->LoadConfig(ini.GetOrCreateSection("Profile"));
+    Wiimote::GetConfig()->GetController(0)->UpdateReferences(g_controller_interface);
+  }
 }
 
 void UpdateHackSettings() {

--- a/Source/Core/Core/PrimeHack/HackConfig.h
+++ b/Source/Core/Core/PrimeHack/HackConfig.h
@@ -76,6 +76,10 @@ CameraLock GetLockCamera();
 bool CheckPitchRecentre();
 bool ControllerMode();
 
+// Used to handle Morphball Controller Switch in WiimoteEmuMetroid.cpp, PrimeHackWiiEmu.cpp, etc.
+std::pair<std::string, std::string> getProfiles();
+void ChangeControllerProfileMorphBall(std::string profile);
+
 double GetHorizontalAxis();
 double GetVerticalAxis();
 

--- a/Source/Core/Core/PrimeHack/HackConfig.h
+++ b/Source/Core/Core/PrimeHack/HackConfig.h
@@ -76,8 +76,7 @@ CameraLock GetLockCamera();
 bool CheckPitchRecentre();
 bool ControllerMode();
 
-// Used to handle Morphball Controller Switch in WiimoteEmuMetroid.cpp, PrimeHackWiiEmu.cpp, etc.
-std::pair<std::string, std::string> getProfiles();
+std::pair<std::string, std::string> GetProfiles();
 void ChangeControllerProfileMorphBall(std::string profile);
 
 double GetHorizontalAxis();

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
@@ -780,29 +780,8 @@ void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
   // Nothing new here
   write32(0, angular_momentum + 0x18);
 
-
-  //This is to avoid constantly load the same profile over and over as that would be slow.
   u32 current_ball_state = read32(ball_state);
-  if (current_ball_state == 1 && !was_in_morph_ball)
-  {
-    //Tell HackConfig to switch the controller profile to Morph Ball preset
-    std::string profile = getProfiles().first;
-
-    //If empty or "None" then we know the user doesn't want to use Morphball preset.
-    if (!profile.empty() && (profile != std::string("None")))
-    {
-      ChangeControllerProfileMorphBall(profile);
-    }
-    was_in_morph_ball = true;
-  }
-  else if (current_ball_state == 0 && was_in_morph_ball)
-  {
-    //Tell HackConfig to switch the controller profile back to the controller's previous preset.
-    std::string profile = getProfiles().second;
-
-    ChangeControllerProfileMorphBall(profile);
-    was_in_morph_ball = false;
-  }
+  swap_morph_profiles(current_ball_state);
 }
 
 void FpsControls::CheckBeamVisorSetting(Game game)

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
@@ -1,7 +1,7 @@
 #include "Core/PrimeHack/Mods/FpsControls.h"
 
 #include "Core/PrimeHack/Mods/ContextSensitiveControls.h"
-#include "Core/PrimeHack/PrimeUtils.h"
+#include "Core/PrimeHack/PrimeUtils.h"  //Loads HackConfig.h for us
 
 #include "Common/Timer.h"
 
@@ -670,6 +670,7 @@ void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
     } else {
       handle_cursor(cursor + 0x9c, cursor + 0x15c, active_region);
     }
+
   };
 
   // Handles menu screen cursor
@@ -778,6 +779,30 @@ void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
 
   // Nothing new here
   write32(0, angular_momentum + 0x18);
+
+
+  //This is to avoid constantly load the same profile over and over as that would be slow.
+  u32 current_ball_state = read32(ball_state);
+  if (current_ball_state == 1 && !was_in_morph_ball)
+  {
+    //Tell HackConfig to switch the controller profile to Morph Ball preset
+    std::string profile = getProfiles().first;
+
+    //If empty or "None" then we know the user doesn't want to use Morphball preset.
+    if (!profile.empty() && (profile != std::string("None")))
+    {
+      ChangeControllerProfileMorphBall(profile);
+    }
+    was_in_morph_ball = true;
+  }
+  else if (current_ball_state == 0 && was_in_morph_ball)
+  {
+    //Tell HackConfig to switch the controller profile back to the controller's previous preset.
+    std::string profile = getProfiles().second;
+
+    ChangeControllerProfileMorphBall(profile);
+    was_in_morph_ball = false;
+  }
 }
 
 void FpsControls::CheckBeamVisorSetting(Game game)

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
@@ -339,6 +339,8 @@ void FpsControls::run_mod_mp1(Region region) {
     if (read32(ball_state) == 0) {
       writef32(calculate_yaw_vel(), angular_momentum);
     }
+
+    swap_morph_profiles(ball_state);
   }
 }
 
@@ -499,6 +501,8 @@ void FpsControls::run_mod_mp2(Region region) {
 
     // Nothing new here
     write32(0, angular_momentum + 0x18);
+
+    swap_morph_profiles(ball_state);
   }
 }
 
@@ -780,8 +784,7 @@ void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
   // Nothing new here
   write32(0, angular_momentum + 0x18);
 
-  u32 current_ball_state = read32(ball_state);
-  swap_morph_profiles(current_ball_state);
+  swap_morph_profiles(ball_state);
 }
 
 void FpsControls::CheckBeamVisorSetting(Game game)

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
@@ -340,7 +340,7 @@ void FpsControls::run_mod_mp1(Region region) {
       writef32(calculate_yaw_vel(), angular_momentum);
     }
 
-    swap_morph_profiles(ball_state);
+    swap_morph_profiles(read32(ball_state));
   }
 }
 
@@ -502,7 +502,7 @@ void FpsControls::run_mod_mp2(Region region) {
     // Nothing new here
     write32(0, angular_momentum + 0x18);
 
-    swap_morph_profiles(ball_state);
+    swap_morph_profiles(read32(ball_state));
   }
 }
 
@@ -784,7 +784,7 @@ void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
   // Nothing new here
   write32(0, angular_momentum + 0x18);
 
-  swap_morph_profiles(ball_state);
+  swap_morph_profiles(read32(ball_state));
 }
 
 void FpsControls::CheckBeamVisorSetting(Game game)

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.h
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.h
@@ -89,5 +89,8 @@ private:
 
   // Check when to reset the cursor position
   bool menu_open = true;
+
+  // Check if we were in the morph ball state last frame.
+  bool was_in_morph_ball = false;
 };
 }

--- a/Source/Core/Core/PrimeHack/PrimeUtils.cpp
+++ b/Source/Core/Core/PrimeHack/PrimeUtils.cpp
@@ -213,7 +213,7 @@ void swap_morph_profiles(u32 ball_state) {
   if (ball_state == 1 && !was_in_morphball) {
     std::string profile = GetProfiles().first;
 
-    if (!profile.empty() && (profile != std::string("None"))) {
+    if (!profile.empty() && (profile != std::string("Disabled"))) {
       ChangeControllerProfileMorphBall(profile);
     }
     was_in_morphball = true;

--- a/Source/Core/Core/PrimeHack/PrimeUtils.cpp
+++ b/Source/Core/Core/PrimeHack/PrimeUtils.cpp
@@ -30,6 +30,7 @@ static int current_visor = 0;
 static std::array<bool, 4> beam_owned = {false, false, false, false};
 static std::array<bool, 4> visor_owned = {false, false, false, false};
 static bool noclip_enabled = false;
+static bool was_in_morphball = false;
 
 std::array<std::array<CodeChange, static_cast<int>(Game::MAX_VAL) + 1>,
   static_cast<int>(Region::MAX_VAL) + 1> noclip_enable_codes;
@@ -206,6 +207,23 @@ int get_beam_switch(std::array<int, 4> const& beams) {
     pressing_button = false;
   }
   return -1;
+}
+
+void swap_morph_profiles(u32 ball_state) {
+  if (ball_state == 1 && !was_in_morphball) {
+    std::string profile = GetProfiles().first;
+
+    if (!profile.empty() && (profile != std::string("None"))) {
+      ChangeControllerProfileMorphBall(profile);
+    }
+    was_in_morphball = true;
+  }
+  else if (ball_state == 0 && was_in_morphball) {
+    std::string profile = GetProfiles().second;
+
+    ChangeControllerProfileMorphBall(profile);
+    was_in_morphball = false;
+  }
 }
 
 std::stringstream ss;

--- a/Source/Core/Core/PrimeHack/PrimeUtils.h
+++ b/Source/Core/Core/PrimeHack/PrimeUtils.h
@@ -62,6 +62,8 @@ void set_beam_owned(int index, bool owned);
 void set_visor_owned(int index, bool owned);
 void set_cursor_pos(float x, float y);
 
+void swap_morph_profiles(u32 ball_state);
+
 void DevInfo(const char* name, const char* format, ...);
 void DevInfoMatrix(const char* name, const Transform& t);
 

--- a/Source/Core/DolphinLib.vcxproj
+++ b/Source/Core/DolphinLib.vcxproj
@@ -55,6 +55,7 @@
     <ClCompile Include="InputCommon\ControllerEmu\ControlGroup\PrimeHackModes.cpp" />
     <ClCompile Include="InputCommon\DInputMouseAbsolute.cpp" />
     <ClCompile Include="InputCommon\GenericMouse.cpp" />
+    <ClCompile Include="InputCommon\ControllerEmu\ControlGroup\PrimeHackMorph.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Core\PrimeHack\AddressDB.h" />
@@ -83,6 +84,7 @@
     <ClInclude Include="InputCommon\ControllerEmu\ControlGroup\PrimeHackModes.h" />
     <ClInclude Include="InputCommon\DInputMouseAbsolute.h" />
     <ClInclude Include="InputCommon\GenericMouse.h" />
+    <ClInclude Include="InputCommon\ControllerEmu\ControlGroup\PrimeHackMorph.h" />
     <ClInclude Include="VideoCommon\PrimePixelErrorTextures.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.cpp
@@ -9,6 +9,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QPushButton>
+#include <qstringbuilder.h>
 
 #include "DolphinQt/Config/Mapping/IOWindow.h"
 #include "DolphinQt/Config/Mapping/MappingButton.h"
@@ -51,9 +52,12 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
   QGroupBox* group_box = new QGroupBox(name);
   QFormLayout* form_layout = new QFormLayout();
 
-  group_box->setLayout(form_layout);
+  QHBoxLayout* m_morph_profiles_layout = nullptr;
+  QComboBox* m_morph_profiles_combo = nullptr;
 
   MappingIndicator* indicator = nullptr;
+
+  group_box->setLayout(form_layout);
 
   switch (group->type)
   {
@@ -88,6 +92,21 @@ QGroupBox* MappingWidget::CreateGroupBox(const QString& name, ControllerEmu::Con
 
   case ControllerEmu::GroupType::Stick:
     indicator = new AnalogStickIndicator(*static_cast<ControllerEmu::ReshapableInput*>(group));
+    break;
+
+  case ControllerEmu::GroupType::PrimeHackMorph:
+    m_morph_profiles_layout = new QHBoxLayout();
+    m_morph_profiles_combo = new QComboBox();
+    m_morph_profiles_combo->setObjectName(tr("ProfileList"));
+
+    //PrimeHack Morphball Controls Layout added to default group layout.
+    form_layout->addRow(m_morph_profiles_layout);
+
+    m_morph_profiles_combo->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+    m_morph_profiles_combo->setMinimumWidth(200);
+    m_morph_profiles_combo->setEditable(true);
+
+    m_morph_profiles_layout->addWidget(m_morph_profiles_combo);
     break;
 
   default:

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -301,6 +301,7 @@ void MappingWindow::OnLoadProfilePressed()
 
   const auto lock = GetController()->GetStateLock();
   emit ConfigChanged();
+  emit ProfileLoaded();
 }
 
 void MappingWindow::OnSaveProfilePressed()
@@ -326,6 +327,8 @@ void MappingWindow::OnSaveProfilePressed()
     PopulateProfileSelection();
     m_profiles_combo->setCurrentIndex(m_profiles_combo->findText(profile_name));
   }
+  emit ConfigChanged();
+  emit ProfileSaved();
 }
 
 void MappingWindow::OnSelectDevice(int)

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -15,6 +15,8 @@
 
 #include "Core/Core.h"
 #include "Core/HotkeyManager.h"
+#include "Core/HW/Wiimote.h"
+#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include "Common/CommonPaths.h"
 #include "Common/FileSearch.h"
@@ -55,6 +57,7 @@
 #include "DolphinQt/Settings.h"
 
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 #include "InputCommon/InputConfig.h"

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
@@ -59,6 +59,8 @@ public:
 signals:
   // Emitted when config has changed so widgets can update to reflect the change.
   void ConfigChanged();
+  void ProfileSaved();
+  void ProfileLoaded();
   // Emitted at 30hz for real-time indicators to be updated.
   void Update();
   void Save();

--- a/Source/Core/DolphinQt/Config/Mapping/PrimeHackEmuWii.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/PrimeHackEmuWii.cpp
@@ -11,16 +11,21 @@
 #include <QRadioButton>
 #include <QLabel>
 
+#include "Common/FileSearch.h"
+#include "Common/FileUtil.h"
+
 #include "Core/HW/Wiimote.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
 #include "InputCommon/InputConfig.h"
 #include "InputCommon/ControllerEmu/ControlGroup/PrimeHackModes.h"
+#include "InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h"
 
 #include "Core/PrimeHack/HackConfig.h"
 
 class PrimeHackModes;
+constexpr const char* PROFILES_DIR = "Profiles/";
 
 PrimeHackEmuWii::PrimeHackEmuWii(MappingWindow* window)
     : MappingWidget(window)
@@ -63,6 +68,15 @@ void PrimeHackEmuWii::CreateMainLayout()
   misc_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
   groupbox1->addWidget(misc_box, 0);
 
+  //TODO:  Look into shrinking this by MAYBE shrinking the button padding to 1 instead of 2???
+  m_morphball_combobox = new QComboBox();
+  m_morphball_combobox->setObjectName(tr("ProfileList"));
+  m_morphball_combobox->setEditable(false);
+  QFormLayout* misc_box_layout = static_cast<QFormLayout*>(misc_box->layout());
+  misc_box_layout->addRow(tr("Morphball Profile"), m_morphball_combobox);
+
+  PopulateMorphBallProfiles();
+
   auto* beam_box = CreateGroupBox(tr("Beams"),
     Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Beams));
 
@@ -99,8 +113,108 @@ void PrimeHackEmuWii::CreateMainLayout()
   setLayout(layout);
 }
 
+void PrimeHackEmuWii::OnMorphControlSelectionChanged()
+{
+  //Called as soon as our selection is changed to update the controller preset for Morphball mode.
+  auto* morph_group = static_cast<ControllerEmu::PrimeHackMorph*>(
+    Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
+
+  std::string curr_text = m_morphball_combobox->currentText().toStdString();
+  if (!curr_text.empty())
+    morph_group->SetMorphBallProfileName(curr_text);
+
+  ConfigChanged();
+  SaveSettings();
+}
+
+void PrimeHackEmuWii::UpdateMorphProfileBackupFile()
+{
+  const std::string og_wiimote_new = WIIMOTE_INI_NAME;
+  const std::string backup_wiimote_new = std::string(WIIMOTE_INI_NAME) + "_Backup.ini";
+
+  const std::string default_path = File::GetUserPath(D_CONFIG_IDX) + og_wiimote_new + ".ini";
+  std::string file_text;
+  if (File::ReadFileToString(default_path, file_text))
+    File::WriteStringToFile(File::GetUserPath(D_CONFIG_IDX) + backup_wiimote_new, file_text);
+}
+
+void PrimeHackEmuWii::PopulateMorphBallProfiles()
+{
+  m_morphball_combobox->clear();
+
+  const std::string profiles_path =
+    File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR + GetConfig()->GetProfileName();
+
+  //Add default value
+  m_morphball_combobox->addItem(QString::fromStdString(std::string("Disabled")),
+    QString::fromStdString(std::string("Disabled")));
+
+  for (const auto& filename : Common::DoFileSearch({ profiles_path }, { ".ini" }))
+  {
+    std::string basename;
+    SplitPath(filename, nullptr, &basename, nullptr);
+    if (!basename.empty())  // Ignore files with an empty name to avoid multiple problems
+      m_morphball_combobox->addItem(QString::fromStdString(basename),
+        QString::fromStdString(filename));
+  }
+
+  m_morphball_combobox->insertSeparator(m_morphball_combobox->count());
+
+  const std::string builtin_profiles_path =
+    File::GetSysDirectory() + PROFILES_DIR + GetConfig()->GetProfileName();
+  for (const auto& filename : Common::DoFileSearch({ builtin_profiles_path }, { ".ini" }))
+  {
+    std::string basename;
+    SplitPath(filename, nullptr, &basename, nullptr);
+    if (!basename.empty())
+    {
+      // i18n: "Stock" refers to input profiles included with Dolphin
+      m_morphball_combobox->addItem(tr("%1 (Stock)").arg(QString::fromStdString(basename)),
+        QString::fromStdString(filename));
+    }
+  }
+
+  auto* morph_group = static_cast<ControllerEmu::PrimeHackMorph*>(
+    Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
+
+  QString text = tr(morph_group->GetMorphBallProfileName().c_str());
+  std::string cstring = morph_group->GetMorphBallProfileName();
+  m_morphball_combobox->setCurrentIndex(m_morphball_combobox->findText(text));
+}
+
+void PrimeHackEmuWii::MappingWindowProfileSave()
+{
+  auto* morph_group = static_cast<ControllerEmu::PrimeHackMorph*>(
+    Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
+
+  std::string curr_text = m_morphball_combobox->currentText().toStdString();
+  if (!curr_text.empty())
+    morph_group->SetMorphBallProfileName(curr_text);
+
+  PopulateMorphBallProfiles();
+  SaveSettings();
+
+  // Backup WiimoteNew.ini to make sure we have the user's control scheme.
+  UpdateMorphProfileBackupFile();
+}
+
+void PrimeHackEmuWii::MappingWindowProfileLoad()
+{
+  PopulateMorphBallProfiles();
+  SaveSettings();
+
+  // Backup WiimoteNew.ini to make sure we have the user's control scheme.
+  UpdateMorphProfileBackupFile();
+}
+
 void PrimeHackEmuWii::Connect(MappingWindow* window)
 {
+  connect(window, &MappingWindow::ProfileSaved, this, &PrimeHackEmuWii::MappingWindowProfileSave);
+  connect(window, &MappingWindow::ProfileLoaded, this, &PrimeHackEmuWii::MappingWindowProfileLoad);
+  connect(window, &MappingWindow::finished, this, &PrimeHackEmuWii::OnMorphControlSelectionChanged);
+  connect(window, &MappingWindow::rejected, this, &PrimeHackEmuWii::MappingWindowProfileSave);
+  connect(m_morphball_combobox, &QComboBox::textActivated, this, &PrimeHackEmuWii::MappingWindowProfileSave);
+
   connect(window, &MappingWindow::ConfigChanged, this, &PrimeHackEmuWii::ConfigChanged);
   connect(window, &MappingWindow::Update, this, &PrimeHackEmuWii::Update);
   connect(m_radio_mouse, &QRadioButton::toggled, this,

--- a/Source/Core/DolphinQt/Config/Mapping/PrimeHackEmuWii.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/PrimeHackEmuWii.cpp
@@ -71,6 +71,7 @@ void PrimeHackEmuWii::CreateMainLayout()
   //TODO:  Look into shrinking this by MAYBE shrinking the button padding to 1 instead of 2???
   m_morphball_combobox = new QComboBox();
   m_morphball_combobox->setObjectName(tr("ProfileList"));
+  m_morphball_combobox->setToolTip(tr("Set the controller profile to use\nwhen in Morph Ball."));
   m_morphball_combobox->setEditable(false);
   QFormLayout* misc_box_layout = static_cast<QFormLayout*>(misc_box->layout());
   misc_box_layout->addRow(tr("Morphball Profile"), m_morphball_combobox);

--- a/Source/Core/DolphinQt/Config/Mapping/PrimeHackEmuWii.h
+++ b/Source/Core/DolphinQt/Config/Mapping/PrimeHackEmuWii.h
@@ -8,6 +8,7 @@
 
 class QRadioButton;
 class QLabel;
+class QComboBox;
 class PrimeHackModes;
 
 class PrimeHackEmuWii final : public MappingWidget
@@ -20,6 +21,7 @@ public:
   QGroupBox* controller_box;
   QRadioButton* m_radio_mouse;
   QRadioButton* m_radio_controller;
+  QComboBox* m_morphball_combobox;
 
 private:
   void LoadSettings() override;
@@ -27,6 +29,11 @@ private:
 
   void CreateMainLayout();
   void Connect(MappingWindow* window);
+  void OnMorphControlSelectionChanged();
+  void UpdateMorphProfileBackupFile();
+  void PopulateMorphBallProfiles();
+  void MappingWindowProfileSave();
+  void MappingWindowProfileLoad();
   void OnDeviceSelected();
   void ConfigChanged();
   void Update();

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
@@ -71,9 +71,9 @@ void WiimoteEmuMetroid::PopulateMorphBallProfiles()
   const std::string profiles_path =
       File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR + GetConfig()->GetProfileName();
 
-  //Add default value "None"
-  m_morphball_combobox->addItem(QString::fromStdString(std::string("None")),
-                                      QString::fromStdString(std::string("None")));
+  //Add default value
+  m_morphball_combobox->addItem(QString::fromStdString(std::string("Disabled")),
+                                      QString::fromStdString(std::string("Disabled")));
 
   for (const auto& filename : Common::DoFileSearch({profiles_path}, {".ini"}))
   {
@@ -106,8 +106,6 @@ void WiimoteEmuMetroid::PopulateMorphBallProfiles()
   QString text = tr(morph_group->GetMorphBallProfileName().c_str());
   std::string cstring = morph_group->GetMorphBallProfileName();
   m_morphball_combobox->setCurrentIndex(m_morphball_combobox->findText(text));
-
-  //m_morphball_combobox->setCurrentIndex(-1);
 }
 
 void WiimoteEmuMetroid::CreateMainLayout()

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
@@ -166,6 +166,7 @@ void WiimoteEmuMetroid::CreateMainLayout()
   groupbox1->addWidget(morphball_control_box);
   m_morphball_combobox = (morphball_control_box->findChild<QComboBox*>(tr("ProfileList")));
   m_morphball_combobox->setToolTip(tr("Set the controller profile to use\nwhen in Morph Ball in MP3."));
+  m_morphball_combobox->setEditable(false);
 
   PopulateMorphBallProfiles();
 

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
@@ -163,7 +163,7 @@ void WiimoteEmuMetroid::CreateMainLayout()
     GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
   groupbox1->addWidget(morphball_control_box);
   m_morphball_combobox = (morphball_control_box->findChild<QComboBox*>(tr("ProfileList")));
-  m_morphball_combobox->setToolTip(tr("Set the controller profile to use\nwhen in Morph Ball in MP3."));
+  m_morphball_combobox->setToolTip(tr("Set the controller profile to use\nwhen in Morph Ball."));
   m_morphball_combobox->setEditable(false);
 
   PopulateMorphBallProfiles();

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
@@ -26,6 +26,7 @@
 #include "DolphinQt/Config/Mapping/WiimoteEmuExtension.h"
 
 #include "InputCommon/ControllerEmu/ControlGroup/Attachments.h"
+#include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerEmu/ControlGroup/PrimeHackModes.h"
 #include "InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h"
 #include "InputCommon/InputConfig.h"
@@ -52,15 +53,26 @@ WiimoteEmuMetroid::WiimoteEmuMetroid(MappingWindow* window, WiimoteEmuExtension*
   SaveSettings();
 }
 
-void WiimoteEmuMetroid::PopulateMorphBallProfiles(QComboBox* combobox)
+void WiimoteEmuMetroid::UpdateMorphProfileBackupFile()
 {
-  combobox->clear();
+  const std::string og_wiimote_new = WIIMOTE_INI_NAME;
+  const std::string backup_wiimote_new = std::string(WIIMOTE_INI_NAME) + "_Backup.ini";
+
+  const std::string default_path = File::GetUserPath(D_CONFIG_IDX) + og_wiimote_new + ".ini";
+  std::string file_text;
+  if (File::ReadFileToString(default_path, file_text))
+    File::WriteStringToFile(File::GetUserPath(D_CONFIG_IDX) + backup_wiimote_new, file_text);
+}
+
+void WiimoteEmuMetroid::PopulateMorphBallProfiles()
+{
+  m_morphball_combobox->clear();
 
   const std::string profiles_path =
       File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR + GetConfig()->GetProfileName();
 
   //Add default value "None"
-  combobox->addItem(QString::fromStdString(std::string("None")),
+  m_morphball_combobox->addItem(QString::fromStdString(std::string("None")),
                                       QString::fromStdString(std::string("None")));
 
   for (const auto& filename : Common::DoFileSearch({profiles_path}, {".ini"}))
@@ -68,11 +80,11 @@ void WiimoteEmuMetroid::PopulateMorphBallProfiles(QComboBox* combobox)
     std::string basename;
     SplitPath(filename, nullptr, &basename, nullptr);
     if (!basename.empty())  // Ignore files with an empty name to avoid multiple problems
-      combobox->addItem(QString::fromStdString(basename),
+      m_morphball_combobox->addItem(QString::fromStdString(basename),
                                       QString::fromStdString(filename));
   }
 
-  combobox->insertSeparator(combobox->count());
+  m_morphball_combobox->insertSeparator(m_morphball_combobox->count());
 
   const std::string builtin_profiles_path =
       File::GetSysDirectory() + PROFILES_DIR + GetConfig()->GetProfileName();
@@ -83,12 +95,19 @@ void WiimoteEmuMetroid::PopulateMorphBallProfiles(QComboBox* combobox)
     if (!basename.empty())
     {
       // i18n: "Stock" refers to input profiles included with Dolphin
-      combobox->addItem(tr("%1 (Stock)").arg(QString::fromStdString(basename)),
+      m_morphball_combobox->addItem(tr("%1 (Stock)").arg(QString::fromStdString(basename)),
                                       QString::fromStdString(filename));
     }
   }
 
-  combobox->setCurrentIndex(-1);
+  auto* morph_group = static_cast<ControllerEmu::PrimeHackMorph*>(
+    Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
+
+  QString text = tr(morph_group->GetMorphBallProfileName().c_str());
+  std::string cstring = morph_group->GetMorphBallProfileName();
+  m_morphball_combobox->setCurrentIndex(m_morphball_combobox->findText(text));
+
+  //m_morphball_combobox->setCurrentIndex(-1);
 }
 
 void WiimoteEmuMetroid::CreateMainLayout()
@@ -147,7 +166,8 @@ void WiimoteEmuMetroid::CreateMainLayout()
   groupbox1->addWidget(morphball_control_box);
   m_morphball_combobox = (morphball_control_box->findChild<QComboBox*>(tr("ProfileList")));
   m_morphball_combobox->setToolTip(tr("Set the controller profile to use\nwhen in Morph Ball in MP3."));
-  PopulateMorphBallProfiles(m_morphball_combobox);
+
+  PopulateMorphBallProfiles();
 
 
   auto* rumble_box = CreateGroupBox(tr("Rumble"), Wiimote::GetWiimoteGroup(
@@ -211,13 +231,19 @@ void WiimoteEmuMetroid::CreateMainLayout()
 
 void WiimoteEmuMetroid::Connect()
 {
+  MappingWindow* parent = GetParent();
+  connect(parent, &MappingWindow::ProfileSaved, this, &WiimoteEmuMetroid::MappingWindowProfileSave);
+  connect(parent, &MappingWindow::ProfileLoaded, this, &WiimoteEmuMetroid::MappingWindowProfileLoad);
   connect(this, &MappingWidget::ConfigChanged, this, &WiimoteEmuMetroid::ConfigChanged);
   connect(this, &MappingWidget::Update, this, &WiimoteEmuMetroid::Update);
   connect(m_radio_mouse, &QRadioButton::toggled, this,
     &WiimoteEmuMetroid::OnDeviceSelected);
   connect(m_radio_controller, &QRadioButton::toggled, this,
     &WiimoteEmuMetroid::OnDeviceSelected);
-  connect(m_morphball_combobox, &QComboBox::currentTextChanged, this, &WiimoteEmuMetroid::OnMorphControlSelectionChanged);
+
+  connect(parent, &MappingWindow::finished, this, &WiimoteEmuMetroid::OnMorphControlSelectionChanged);
+  connect(parent, &MappingWindow::rejected, this, &WiimoteEmuMetroid::MappingWindowProfileSave);
+  connect(m_morphball_combobox, &QComboBox::textActivated, this, &WiimoteEmuMetroid::MappingWindowProfileSave);
 }
 
 void WiimoteEmuMetroid::OnDeviceSelected()
@@ -239,22 +265,40 @@ void WiimoteEmuMetroid::OnMorphControlSelectionChanged()
       Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
 
   std::string curr_text = m_morphball_combobox->currentText().toStdString();
-  morph_group->SetMorphBallProfileName(curr_text);
+  if (!curr_text.empty())
+    morph_group->SetMorphBallProfileName(curr_text);
 
   ConfigChanged();
   SaveSettings();
 }
 
-void WiimoteEmuMetroid::ConfigChanged()
+void WiimoteEmuMetroid::MappingWindowProfileLoad()
 {
-  //Adding for morphcombo to update on pressing Load button for profile.
+  PopulateMorphBallProfiles();
+  SaveSettings();
+
+  // Backup WiimoteNew.ini to make sure we have the user's control scheme.
+  UpdateMorphProfileBackupFile();
+}
+
+void WiimoteEmuMetroid::MappingWindowProfileSave()
+{
   auto* morph_group = static_cast<ControllerEmu::PrimeHackMorph*>(
     Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
 
-  QString text = tr(morph_group->GetMorphBallProfileName().c_str());
+  std::string curr_text = m_morphball_combobox->currentText().toStdString();
+  if (!curr_text.empty())
+    morph_group->SetMorphBallProfileName(curr_text);
 
-  m_morphball_combobox->setCurrentIndex(m_morphball_combobox->findText(text));
+  PopulateMorphBallProfiles();
+  SaveSettings();
 
+  // Backup WiimoteNew.ini to make sure we have the user's control scheme.
+  UpdateMorphProfileBackupFile();
+}
+
+void WiimoteEmuMetroid::ConfigChanged()
+{
   return; // All this does is update the extension UI, which we do not have.
 }
 

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
@@ -159,7 +159,7 @@ void WiimoteEmuMetroid::CreateMainLayout()
       GetPort(), WiimoteEmu::WiimoteGroup::Visors));
   groupbox1->addWidget(visor_box);
 
-  auto* morphball_control_box = CreateGroupBox(tr("Morphball Controller Profile"), Wiimote::GetWiimoteGroup(
+  auto* morphball_control_box = CreateGroupBox(tr("Morphball Profile"), Wiimote::GetWiimoteGroup(
     GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
   groupbox1->addWidget(morphball_control_box);
   m_morphball_combobox = (morphball_control_box->findChild<QComboBox*>(tr("ProfileList")));

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
@@ -13,20 +13,28 @@
 #include <QRadioButton>
 #include <QTimer>
 
+#include "Common/FileUtil.h"
+#include "Common/FileSearch.h"
+
 #include "Core/HW/Wiimote.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
 #include "Core/PrimeHack/HackConfig.h"
+#include "Core/PrimeHack/HackManager.h"
 
 #include "DolphinQt/Config/Mapping/MappingWindow.h"
 #include "DolphinQt/Config/Mapping/WiimoteEmuExtension.h"
 
 #include "InputCommon/ControllerEmu/ControlGroup/Attachments.h"
 #include "InputCommon/ControllerEmu/ControlGroup/PrimeHackModes.h"
+#include "InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h"
 #include "InputCommon/InputConfig.h"
+
 
 #include <QDesktopServices>
 #include <QUrl>
+
+constexpr const char* PROFILES_DIR = "Profiles/";
 
 WiimoteEmuMetroid::WiimoteEmuMetroid(MappingWindow* window, WiimoteEmuExtension* extension)
     : MappingWidget(window), m_extension_widget(extension)
@@ -42,6 +50,45 @@ WiimoteEmuMetroid::WiimoteEmuMetroid(MappingWindow* window, WiimoteEmuExtension*
 
   ConfigChanged();
   SaveSettings();
+}
+
+void WiimoteEmuMetroid::PopulateMorphBallProfiles(QComboBox* combobox)
+{
+  combobox->clear();
+
+  const std::string profiles_path =
+      File::GetUserPath(D_CONFIG_IDX) + PROFILES_DIR + GetConfig()->GetProfileName();
+
+  //Add default value "None"
+  combobox->addItem(QString::fromStdString(std::string("None")),
+                                      QString::fromStdString(std::string("None")));
+
+  for (const auto& filename : Common::DoFileSearch({profiles_path}, {".ini"}))
+  {
+    std::string basename;
+    SplitPath(filename, nullptr, &basename, nullptr);
+    if (!basename.empty())  // Ignore files with an empty name to avoid multiple problems
+      combobox->addItem(QString::fromStdString(basename),
+                                      QString::fromStdString(filename));
+  }
+
+  combobox->insertSeparator(combobox->count());
+
+  const std::string builtin_profiles_path =
+      File::GetSysDirectory() + PROFILES_DIR + GetConfig()->GetProfileName();
+  for (const auto& filename : Common::DoFileSearch({builtin_profiles_path}, {".ini"}))
+  {
+    std::string basename;
+    SplitPath(filename, nullptr, &basename, nullptr);
+    if (!basename.empty())
+    {
+      // i18n: "Stock" refers to input profiles included with Dolphin
+      combobox->addItem(tr("%1 (Stock)").arg(QString::fromStdString(basename)),
+                                      QString::fromStdString(filename));
+    }
+  }
+
+  combobox->setCurrentIndex(-1);
 }
 
 void WiimoteEmuMetroid::CreateMainLayout()
@@ -94,6 +141,13 @@ void WiimoteEmuMetroid::CreateMainLayout()
   auto* visor_box = CreateGroupBox(tr("Visors"), Wiimote::GetWiimoteGroup(
       GetPort(), WiimoteEmu::WiimoteGroup::Visors));
   groupbox1->addWidget(visor_box);
+
+  auto* morphball_control_box = CreateGroupBox(tr("Morphball Controller Profile"), Wiimote::GetWiimoteGroup(
+    GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
+  groupbox1->addWidget(morphball_control_box);
+  m_morphball_combobox = (morphball_control_box->findChild<QComboBox*>(tr("ProfileList")));
+  m_morphball_combobox->setToolTip(tr("Set the controller profile to use\nwhen in Morph Ball in MP3."));
+  PopulateMorphBallProfiles(m_morphball_combobox);
 
 
   auto* rumble_box = CreateGroupBox(tr("Rumble"), Wiimote::GetWiimoteGroup(
@@ -163,6 +217,7 @@ void WiimoteEmuMetroid::Connect()
     &WiimoteEmuMetroid::OnDeviceSelected);
   connect(m_radio_controller, &QRadioButton::toggled, this,
     &WiimoteEmuMetroid::OnDeviceSelected);
+  connect(m_morphball_combobox, &QComboBox::currentTextChanged, this, &WiimoteEmuMetroid::OnMorphControlSelectionChanged);
 }
 
 void WiimoteEmuMetroid::OnDeviceSelected()
@@ -177,8 +232,29 @@ void WiimoteEmuMetroid::OnDeviceSelected()
   SaveSettings();
 }
 
+void WiimoteEmuMetroid::OnMorphControlSelectionChanged()
+{
+  //Called as soon as our selection is changed to update the controller preset for Morphball mode.
+  auto* morph_group = static_cast<ControllerEmu::PrimeHackMorph*>(
+      Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
+
+  std::string curr_text = m_morphball_combobox->currentText().toStdString();
+  morph_group->SetMorphBallProfileName(curr_text);
+
+  ConfigChanged();
+  SaveSettings();
+}
+
 void WiimoteEmuMetroid::ConfigChanged()
 {
+  //Adding for morphcombo to update on pressing Load button for profile.
+  auto* morph_group = static_cast<ControllerEmu::PrimeHackMorph*>(
+    Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
+
+  QString text = tr(morph_group->GetMorphBallProfileName().c_str());
+
+  m_morphball_combobox->setCurrentIndex(m_morphball_combobox->findText(text));
+
   return; // All this does is update the extension UI, which we do not have.
 }
 
@@ -198,6 +274,9 @@ void WiimoteEmuMetroid::LoadSettings()
 {
   Wiimote::LoadConfig(); // No need to update hack settings since it's already in LoadConfig.
 
+  auto* morph_group = static_cast<ControllerEmu::PrimeHackMorph*>(
+    Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::MorphballControls));
+
   auto* modes = static_cast<ControllerEmu::PrimeHackModes*>(
     Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Modes));
 
@@ -216,6 +295,11 @@ void WiimoteEmuMetroid::LoadSettings()
   m_radio_mouse->setChecked(checked);
   m_radio_controller->setChecked(!checked);
   camera_control->setEnabled(!checked);
+
+  QString text = tr(morph_group->GetMorphBallProfileName().c_str());
+
+  m_morphball_combobox->setCurrentIndex(m_morphball_combobox->findText(text));
+
 }
 
 void WiimoteEmuMetroid::SaveSettings()

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.h
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.h
@@ -31,12 +31,15 @@ private:
   void LoadSettings() override;
   void SaveSettings() override;
   void CreateMainLayout();
-  void PopulateMorphBallProfiles(QComboBox* combobox);
+  void UpdateMorphProfileBackupFile();
+  void PopulateMorphBallProfiles();
   void Connect();
 
   void OnDeviceSelected();
   void OnMorphControlSelectionChanged();
   void ConfigChanged();
+  void MappingWindowProfileSave();
+  void MappingWindowProfileLoad();
   void Update();
 
   WiimoteEmuExtension* m_extension_widget;

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.h
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.h
@@ -6,6 +6,8 @@
 
 #include "DolphinQt/Config/Mapping/MappingWidget.h"
 
+class QHBoxLayout;
+class QGroupBox;
 class QComboBox;
 class QLabel;
 class QRadioButton;
@@ -23,13 +25,17 @@ public:
   QRadioButton* m_radio_mouse;
   QRadioButton* m_radio_controller;
   QPushButton* m_help_button;
+  QComboBox* m_morphball_combobox;
+
 private:
   void LoadSettings() override;
   void SaveSettings() override;
   void CreateMainLayout();
+  void PopulateMorphBallProfiles(QComboBox* combobox);
   void Connect();
 
   void OnDeviceSelected();
+  void OnMorphControlSelectionChanged();
   void ConfigChanged();
   void Update();
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -5,6 +5,11 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
+#include "Common/FileSearch.h"
+#include "Common/FileUtil.h"
+#include "Common/IOFile.h"
+
+#include "Core/HW/Wiimote.h"
 
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/Control/Input.h"
@@ -13,6 +18,7 @@
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 #include "InputCommon/ControllerEmu/ControlGroup/PrimeHackModes.h"
+#include "InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h"
 
 namespace ControllerEmu
 {
@@ -61,7 +67,7 @@ void ControlGroup::LoadConfig(IniFile::Section* sec, const std::string& defdev,
 
   for (auto& setting : numeric_settings)
     setting->LoadFromIni(*sec, group);
-
+  
   for (auto& c : controls)
   {
     {
@@ -114,13 +120,22 @@ void ControlGroup::LoadConfig(IniFile::Section* sec, const std::string& defdev,
   }
 
   // extensions
-  if (type == GroupType::PrimeHack)
+  if (type == GroupType::PrimeHackMode)
   {
     auto* const ext = static_cast<PrimeHackModes*>(this);
 
     std::string i;
     sec->Get(base + name + "/Mode", &i, "0");
     ext->SetSelectedDevice(stoi(i));
+  }
+
+  if (type == GroupType::PrimeHackMorph)
+  {
+    auto* const ext = static_cast<PrimeHackMorph*>(this);
+
+    std::string prof;
+    sec->Get(base + name + "/MorphBallProfile", &prof);
+    ext->SetMorphBallProfileName(prof);
   }
 }
 
@@ -177,11 +192,31 @@ void ControlGroup::SaveConfig(IniFile::Section* sec, const std::string& defdev,
       ai->SaveConfig(sec, base + ai->GetName() + "/");
   }
 
-  if (type == GroupType::PrimeHack)
+  if (type == GroupType::PrimeHackMode)
   {
     auto* const ext = static_cast<PrimeHackModes*>(this);
 
     sec->Set(base + name + "/Mode", std::to_string(ext->GetSelectedDevice()), "0");
+  }
+
+  if (type == GroupType::PrimeHackMorph)
+  {
+    auto* const ext = static_cast<PrimeHackMorph*>(this);
+
+    std::string morph_prof = ext->GetMorphBallProfileName();
+    if (morph_prof.empty())
+      morph_prof = "None";
+    sec->Set(base + name + "/MorphBallProfile", morph_prof);
+
+
+    // Go ahead and save out the backup of this profile for when in-game.
+    const std::string og_wiimote_new = WIIMOTE_INI_NAME;
+    const std::string backup_wiimote_new = std::string(WIIMOTE_INI_NAME) + "_Backup.ini";
+
+    const std::string default_path = File::GetUserPath(D_CONFIG_IDX) + og_wiimote_new + ".ini";
+    std::string file_text;
+    if (File::ReadFileToString(default_path, file_text))
+      File::WriteStringToFile(File::GetUserPath(D_CONFIG_IDX) + backup_wiimote_new, file_text);
   }
 }
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -205,7 +205,7 @@ void ControlGroup::SaveConfig(IniFile::Section* sec, const std::string& defdev,
 
     std::string morph_prof = ext->GetMorphBallProfileName();
     if (morph_prof.empty())
-      morph_prof = "None";
+      morph_prof = "Disabled";
     sec->Set(base + name + "/MorphBallProfile", morph_prof);
 
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -43,7 +43,8 @@ enum class GroupType
   IMUAccelerometer,
   IMUGyroscope,
   IMUCursor,
-  PrimeHack
+  PrimeHackMode,
+  PrimeHackMorph
 };
 
 class ControlGroup

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackModes.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackModes.cpp
@@ -3,7 +3,7 @@
 
 namespace ControllerEmu
 {
-  PrimeHackModes::PrimeHackModes(const std::string& name_) : ControlGroup(name_, GroupType::PrimeHack)
+  PrimeHackModes::PrimeHackModes(const std::string& name_) : ControlGroup(name_, GroupType::PrimeHackMode)
   {
   }
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.cpp
@@ -1,0 +1,31 @@
+#include "InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h"
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
+
+namespace ControllerEmu
+{
+  PrimeHackMorph::PrimeHackMorph(const std::string& name_, const std::string& default_selection)
+    : ControlGroup(name_, GroupType::PrimeHackMorph), m_selection_value(default_selection)
+  {
+  }
+
+    // Returns the MorphBall Profile
+  const std::string& PrimeHackMorph::GetMorphBallProfileName() const
+  {
+    return m_selection_value;
+  }
+
+  const std::string& PrimeHackMorph::GetMainProfileName() const
+  {
+    return m_previous_selection;
+  }
+
+  void PrimeHackMorph::SetMorphBallProfileName(std::string& val)
+  {
+    m_selection_value = val;
+  }
+
+  void PrimeHackMorph::SetMainProfileName(std::string& val)
+  {
+    m_previous_selection = val;
+  }
+}  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.cpp
@@ -14,18 +14,8 @@ namespace ControllerEmu
     return m_selection_value;
   }
 
-  const std::string& PrimeHackMorph::GetMainProfileName() const
-  {
-    return m_previous_selection;
-  }
-
   void PrimeHackMorph::SetMorphBallProfileName(std::string& val)
   {
     m_selection_value = val;
-  }
-
-  void PrimeHackMorph::SetMainProfileName(std::string& val)
-  {
-    m_previous_selection = val;
   }
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h
@@ -1,0 +1,33 @@
+// Copyright 2017 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "Common/CommonTypes.h"
+#include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
+#include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
+
+namespace ControllerEmu
+{
+  class PrimeHackMorph : public ControlGroup
+  {
+  public:
+    explicit PrimeHackMorph(const std::string& name, const std::string& default_selection);
+
+    const std::string& GetMorphBallProfileName() const;
+    const std::string& GetMainProfileName() const;
+    void SetMorphBallProfileName(std::string& val);
+    void SetMainProfileName(std::string& val);
+
+  private:
+    std::string m_selection_value;
+    std::string m_previous_selection;
+  };
+}  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackMorph.h
@@ -22,9 +22,7 @@ namespace ControllerEmu
     explicit PrimeHackMorph(const std::string& name, const std::string& default_selection);
 
     const std::string& GetMorphBallProfileName() const;
-    const std::string& GetMainProfileName() const;
     void SetMorphBallProfileName(std::string& val);
-    void SetMainProfileName(std::string& val);
 
   private:
     std::string m_selection_value;

--- a/Source/Core/InputCommon/InputConfig.h
+++ b/Source/Core/InputCommon/InputConfig.h
@@ -20,7 +20,7 @@ class InputConfig
 {
 public:
   InputConfig(const std::string& ini_name, const std::string& gui_name,
-              const std::string& profile_name);
+    const std::string& profile_name);
 
   ~InputConfig();
 


### PR DESCRIPTION
User can make a profile using the conventional means of doing so.  The profile can then be selected in the "Morphball Controller Profile" drop-down box, as they would any normal profile.  The profile loads immediately upon selection in the drop down and can be saved within and loaded from existing profiles as expected.

This allows setting up custom controls specifically for when Samus is in Morph Ball and will automatically revert back to user's previous profile when returning from Morph Ball.  This the first part of a few features I'm working on to allow players to play Metroid Prime 3 using classic Gamecube-style Prime1/2 controls.

I'll update this PR from draft to full PR once I've had time to add the profile system to the standard Emulated Wiimote's PrimeHack tab.