### PR TITLE
macOS Mouse Interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 3.10)
 # This is done in the universal binary building script to build a binary that 
 # runs on 10.13 on x86_64 computers, while still containing an arm64 slice.
 
- set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "")
 
 set(CMAKE_USER_MAKE_RULES_OVERRIDE "CMake/FlagsOverride.cmake")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 3.10)
 # This is done in the universal binary building script to build a binary that 
 # runs on 10.13 on x86_64 computers, while still containing an arm64 slice.
 
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14.0" CACHE STRING "")
+ set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0" CACHE STRING "")
 
 set(CMAKE_USER_MAKE_RULES_OVERRIDE "CMake/FlagsOverride.cmake")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 3.10)
 # This is done in the universal binary building script to build a binary that 
 # runs on 10.13 on x86_64 computers, while still containing an arm64 slice.
 
- set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0" CACHE STRING "")
+ set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "")
 
 set(CMAKE_USER_MAKE_RULES_OVERRIDE "CMake/FlagsOverride.cmake")
 

--- a/Externals/MoltenVK/patches/fix-shared-buffer-view.patch
+++ b/Externals/MoltenVK/patches/fix-shared-buffer-view.patch
@@ -1,0 +1,21 @@
+diff --git a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+index 7975f72b..6239b967 100644
+--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
++++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+@@ -311,7 +311,16 @@
+                                                                             width: _textureSize.width
+                                                                            height: _textureSize.height
+                                                                         mipmapped: NO];
++#if MVK_MACOS
++        // Textures on Mac cannot use shared storage, so force managed.
++        if (_buffer->getMTLBuffer().storageMode == MTLStorageModeShared) {
++            mtlTexDesc.storageMode = MTLStorageModeManaged;
++        } else {
++            mtlTexDesc.storageMode = _buffer->getMTLBuffer().storageMode;
++        }
++#else
+             mtlTexDesc.storageMode = mtlBuff.storageMode;
++#endif
+             mtlTexDesc.cpuCacheMode = mtlBuff.cpuCacheMode;
+             mtlTexDesc.usage = usage;
+         }

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -558,9 +558,11 @@ if(APPLE)
     set_source_files_properties("${SOURCE_DIR}/Package/Release/MoltenVK/dylib/macOS/libMoltenVK.dylib" PROPERTIES MACOSX_PACKAGE_LOCATION Frameworks GENERATED ON)
   endif()
 
-  # Update library references to make the bundle portable
-  include(DolphinPostprocessBundle)
-  dolphin_postprocess_bundle(dolphin-emu)
+  if(NOT APPLE)
+    # Update library references to make the bundle portable
+    include(DolphinPostprocessBundle)
+    dolphin_postprocess_bundle(dolphin-emu)
+ endif()
   # Fix rpath
   add_custom_command(TARGET dolphin-emu
     POST_BUILD COMMAND

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -562,7 +562,7 @@ if(APPLE)
     # Update library references to make the bundle portable
     include(DolphinPostprocessBundle)
     dolphin_postprocess_bundle(dolphin-emu)
- endif()
+  endif()
   # Fix rpath
   add_custom_command(TARGET dolphin-emu
     POST_BUILD COMMAND

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -447,7 +447,7 @@ bool RenderWidget::event(QEvent* event)
     emit FocusChanged(false);
     break;
   case QEvent::Move:
-#if defined(CIFACE_USE_WIN32) || defined(CIFACE_USE_XLIB) 
+#if defined(CIFACE_USE_WIN32) || defined(CIFACE_USE_XLIB) || defined(CIFACE_USE_OSX)
     SetCursorLocked(m_cursor_locked);
     win_w = size().width() / 2;
     win_h = size().height() / 2;
@@ -456,7 +456,7 @@ bool RenderWidget::event(QEvent* event)
     break;
   case QEvent::Resize:
   {
-#if defined(CIFACE_USE_WIN32) || defined(CIFACE_USE_XLIB) 
+#if defined(CIFACE_USE_WIN32) || defined(CIFACE_USE_XLIB) || defined(CIFACE_USE_OSX)
     const QResizeEvent* se = static_cast<QResizeEvent*>(event);
     QSize new_size = se->size();
 

--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -111,6 +111,8 @@ if(WIN32)
   )
 elseif(APPLE)
   target_sources(inputcommon PRIVATE
+    QuartzInputMouse.h
+    QuartzInputMouse.mm
     ControllerInterface/OSX/OSX.h
     ControllerInterface/OSX/OSX.mm
     ControllerInterface/OSX/OSXJoystick.h

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackModes.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/PrimeHackModes.cpp
@@ -21,7 +21,7 @@ namespace ControllerEmu
   // Check to see if we're on a platform with a mouse class.
   bool PrimeHackModes::GetMouseSupported() const
   {
-#if defined CIFACE_USE_WIN32 || defined CIFACE_USE_XLIB
+#if defined CIFACE_USE_WIN32 || defined CIFACE_USE_XLIB || defined CIFACE_USE_OSX
     return true;
 #else
     return false;

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
@@ -9,6 +9,7 @@
 #include <Cocoa/Cocoa.h>
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
+#include "InputCommon/QuartzInputMouse.h"
 
 namespace ciface::Quartz
 {
@@ -141,7 +142,7 @@ KeyboardAndMouse::KeyboardAndMouse(void* view)
   // keys that aren't being recognized, bump this number up!
   for (int keycode = 0; keycode < 0x80; ++keycode)
     AddInput(new Key(keycode));
-
+  
   // Add combined left/right modifiers with consistent naming across platforms.
   AddCombinedInput("Alt", {"Left Alt", "Right Alt"});
   AddCombinedInput("Shift", {"Left Shift", "Right Shift"});
@@ -161,6 +162,7 @@ KeyboardAndMouse::KeyboardAndMouse(void* view)
       m_windowid = [[cocoa_view window] windowNumber];
     });
   }
+  prime::InitCocoaInputMouse(&m_windowid);
 
   // cursor, with a hax for-loop
   for (unsigned int i = 0; i < 4; ++i)
@@ -175,6 +177,7 @@ void KeyboardAndMouse::UpdateInput()
 {
   CGRect bounds = CGRectZero;
   CGWindowID windowid[1] = {m_windowid};
+  
   CFArrayRef windowArray = CFArrayCreate(nullptr, (const void**)windowid, 1, nullptr);
   CFArrayRef windowDescriptions = CGWindowListCreateDescriptionFromArray(windowArray);
   CFDictionaryRef windowDescription =

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
@@ -142,7 +142,7 @@ KeyboardAndMouse::KeyboardAndMouse(void* view)
   // keys that aren't being recognized, bump this number up!
   for (int keycode = 0; keycode < 0x80; ++keycode)
     AddInput(new Key(keycode));
-  
+
   // Add combined left/right modifiers with consistent naming across platforms.
   AddCombinedInput("Alt", {"Left Alt", "Right Alt"});
   AddCombinedInput("Shift", {"Left Shift", "Right Shift"});
@@ -162,7 +162,7 @@ KeyboardAndMouse::KeyboardAndMouse(void* view)
       m_windowid = [[cocoa_view window] windowNumber];
     });
   }
-  prime::InitCocoaInputMouse(&m_windowid);
+  prime::InitQuartzInputMouse(&m_windowid);
 
   // cursor, with a hax for-loop
   for (unsigned int i = 0; i < 4; ++i)
@@ -177,7 +177,6 @@ void KeyboardAndMouse::UpdateInput()
 {
   CGRect bounds = CGRectZero;
   CGWindowID windowid[1] = {m_windowid};
-  
   CFArrayRef windowArray = CFArrayCreate(nullptr, (const void**)windowid, 1, nullptr);
   CFArrayRef windowDescriptions = CGWindowListCreateDescriptionFromArray(windowArray);
   CFDictionaryRef windowDescription =

--- a/Source/Core/InputCommon/QuartzInputMouse.h
+++ b/Source/Core/InputCommon/QuartzInputMouse.h
@@ -4,7 +4,7 @@
 namespace prime
 {
 
-bool InitCocoaInputMouse(uint32_t* windowid);
+bool InitQuartzInputMouse(uint32_t* windowid);
 
 class QuartzInputMouse: public GenericMouse
 {

--- a/Source/Core/InputCommon/QuartzInputMouse.h
+++ b/Source/Core/InputCommon/QuartzInputMouse.h
@@ -5,20 +5,20 @@ namespace prime
 {
 
 bool InitCocoaInputMouse(uint32_t* windowid);
-CGRect getBounds(uint32_t* m_windowid);
-CGPoint getWindowCenter(uint32_t* m_windowid);
 
-class CocoaInputMouse: public GenericMouse
+class QuartzInputMouse: public GenericMouse
 {
 public:
-  explicit CocoaInputMouse(uint32_t* windowid);
+  explicit QuartzInputMouse(uint32_t* windowid);
   void UpdateInput() override;
   void LockCursorToGameWindow() override;
 
 private:
   CGPoint current_loc, center;
-  CGEventRef event;
+  CGEventRef event{};
   uint32_t* m_windowid;
+  CGRect getBounds();
+  CGPoint getWindowCenter();
 };
 
 }

--- a/Source/Core/InputCommon/QuartzInputMouse.h
+++ b/Source/Core/InputCommon/QuartzInputMouse.h
@@ -11,15 +11,13 @@ CGPoint getWindowCenter(uint32_t* m_windowid);
 class CocoaInputMouse: public GenericMouse
 {
 public:
-  CocoaInputMouse(uint32_t* windowid);
+  explicit CocoaInputMouse(uint32_t* windowid);
   void UpdateInput() override;
   void LockCursorToGameWindow() override;
 
 private:
-  bool isFullScreen();
-  CGPoint current_loc, last_loc, origin;
+  CGPoint current_loc, center;
   CGEventRef event;
-  static const uint8 WINDOW_CHROME_OFFSET = 13;
   uint32_t* m_windowid;
 };
 

--- a/Source/Core/InputCommon/QuartzInputMouse.h
+++ b/Source/Core/InputCommon/QuartzInputMouse.h
@@ -1,0 +1,26 @@
+#include <ApplicationServices/ApplicationServices.h>
+#include "GenericMouse.h"
+
+namespace prime
+{
+
+bool InitCocoaInputMouse(uint32_t* windowid);
+CGRect getBounds(uint32_t* m_windowid);
+CGPoint getWindowCenter(uint32_t* m_windowid);
+
+class CocoaInputMouse: public GenericMouse
+{
+public:
+  CocoaInputMouse(uint32_t* windowid);
+  void UpdateInput() override;
+  void LockCursorToGameWindow() override;
+
+private:
+  bool isFullScreen();
+  CGPoint current_loc, last_loc, origin;
+  CGEventRef event;
+  static const uint8 WINDOW_CHROME_OFFSET = 13;
+  uint32_t* m_windowid;
+};
+
+}

--- a/Source/Core/InputCommon/QuartzInputMouse.mm
+++ b/Source/Core/InputCommon/QuartzInputMouse.mm
@@ -1,6 +1,3 @@
-#include <iostream>
-#include <math.h>
-
 #include "QuartzInputMouse.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "Core/Host.h"

--- a/Source/Core/InputCommon/QuartzInputMouse.mm
+++ b/Source/Core/InputCommon/QuartzInputMouse.mm
@@ -14,7 +14,7 @@ int win_w = 0, win_h = 0;
 namespace prime
 {
 
-bool InitCocoaInputMouse(uint32_t* windowid)
+bool InitQuartzInputMouse(uint32_t* windowid)
 {
   g_mouse_input = new QuartzInputMouse(windowid);
   return true;

--- a/Source/Core/InputCommon/QuartzInputMouse.mm
+++ b/Source/Core/InputCommon/QuartzInputMouse.mm
@@ -1,0 +1,104 @@
+#include <iostream>
+#include <math.h>
+
+#include "QuartzInputMouse.h"
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
+#include "Core/Host.h"
+
+
+int win_w = 0, win_h = 0;
+
+namespace prime
+{
+
+bool InitCocoaInputMouse(uint32_t* windowid)
+{
+  g_mouse_input = new CocoaInputMouse(windowid);
+  return true;
+}
+
+CocoaInputMouse::CocoaInputMouse(uint32_t* windowid)
+{
+  m_windowid = windowid;
+  origin = last_loc = getWindowCenter(m_windowid);
+}
+
+void CocoaInputMouse::UpdateInput() 
+{
+  event = CGEventCreate(nil);
+  current_loc = CGEventGetLocation(event);
+  CFRelease(event);
+  origin = getWindowCenter(m_windowid);
+
+  if (cursor_locked)
+  {
+      this->dx += current_loc.x - origin.x;
+      this->dy += current_loc.y - origin.y;
+      if (!isFullScreen()) {
+        this->dy -= WINDOW_CHROME_OFFSET;
+      }
+      last_loc = current_loc;
+  }
+  LockCursorToGameWindow();
+
+}
+
+void CocoaInputMouse::LockCursorToGameWindow()
+{
+  if (Host_RendererHasFocus() && cursor_locked)
+  {
+    Host_RendererUpdateCursor(true);
+    CGDisplayHideCursor(CGMainDisplayID());
+  }
+  else
+  {
+    cursor_locked = false;
+    Host_RendererUpdateCursor(false);
+    CGDisplayShowCursor(CGMainDisplayID());
+  }
+}
+
+bool CocoaInputMouse::isFullScreen()
+{
+  // TODO: Right now the game must be played on the main display.
+  auto bounds = getBounds(m_windowid);
+  auto mainDisplayId = CGMainDisplayID();
+  auto width = CGDisplayPixelsWide(mainDisplayId);
+  auto height = CGDisplayPixelsHigh(mainDisplayId);
+  return (bounds.size.width == width && bounds.size.height == height);
+}
+
+CGRect getBounds(uint32_t* m_windowid)
+{
+  CGRect bounds = CGRectZero;
+  CGWindowID windowid[1] = {*m_windowid};
+  
+  CFArrayRef windowArray = CFArrayCreate(nullptr, (const void**)windowid, 1, nullptr);
+  CFArrayRef windowDescriptions = CGWindowListCreateDescriptionFromArray(windowArray);
+  CFDictionaryRef windowDescription =
+      static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(windowDescriptions, 0));
+
+  if (CFDictionaryContainsKey(windowDescription, kCGWindowBounds))
+  {
+    CFDictionaryRef boundsDictionary =
+        static_cast<CFDictionaryRef>(CFDictionaryGetValue(windowDescription, kCGWindowBounds));
+
+    if (boundsDictionary != nullptr)
+      CGRectMakeWithDictionaryRepresentation(boundsDictionary, &bounds);
+  }
+
+  CFRelease(windowDescriptions);
+  CFRelease(windowArray);
+  return bounds;
+}
+
+CGPoint getWindowCenter(uint32_t* m_windowid)
+{
+  auto bounds = getBounds(m_windowid);
+  double x = bounds.origin.x + (bounds.size.width / 2);
+  double y = bounds.origin.y + (bounds.size.height / 2);
+  CGPoint center = {x, y};
+  return center;
+}
+
+}

--- a/Source/Core/InputCommon/QuartzInputMouse.mm
+++ b/Source/Core/InputCommon/QuartzInputMouse.mm
@@ -16,22 +16,22 @@ namespace prime
 
 bool InitCocoaInputMouse(uint32_t* windowid)
 {
-  g_mouse_input = new CocoaInputMouse(windowid);
+  g_mouse_input = new QuartzInputMouse(windowid);
   return true;
 }
 
-CocoaInputMouse::CocoaInputMouse(uint32_t* windowid)
+QuartzInputMouse::QuartzInputMouse(uint32_t* windowid)
 {
   m_windowid = windowid;
-  center = getWindowCenter(m_windowid);
+  center = current_loc = getWindowCenter();
 }
 
-void CocoaInputMouse::UpdateInput() 
+void QuartzInputMouse::UpdateInput()
 {
   event = CGEventCreate(nil);
   current_loc = CGEventGetLocation(event);
   CFRelease(event);
-  center = getWindowCenter(m_windowid);
+  center = getWindowCenter();
   if (Host_RendererHasFocus() && cursor_locked)
   {
     this->dx += current_loc.x - center.x;
@@ -40,11 +40,11 @@ void CocoaInputMouse::UpdateInput()
   LockCursorToGameWindow();
 }
 
-void CocoaInputMouse::LockCursorToGameWindow()
+void QuartzInputMouse::LockCursorToGameWindow()
 {
   if (Host_RendererHasFocus() && cursor_locked)
   {
-    // Hack to avoid short bit of input supression after warp
+    // Hack to avoid short bit of input suppression after warp
     // Credit/explanation: https://stackoverflow.com/a/17559012/7341382
       CGWarpMouseCursorPosition(center);
       CGAssociateMouseAndMouseCursorPosition(true);
@@ -59,7 +59,7 @@ void CocoaInputMouse::LockCursorToGameWindow()
   }
 }
 
-CGRect getBounds(uint32_t* m_windowid)
+CGRect QuartzInputMouse::getBounds()
 {
   CGRect bounds = CGRectZero;
   CGWindowID windowid[1] = {*m_windowid};
@@ -83,13 +83,12 @@ CGRect getBounds(uint32_t* m_windowid)
   return bounds;
 }
 
-CGPoint getWindowCenter(uint32_t* m_windowid)
+CGPoint QuartzInputMouse::getWindowCenter()
 {
-  auto bounds = getBounds(m_windowid);
-  double x = bounds.origin.x + (bounds.size.width / 2);
-  double y = bounds.origin.y + (bounds.size.height / 2);
-  CGPoint center = {x, y};
-  return center;
+  const auto bounds = getBounds();
+  const double x = bounds.origin.x + (bounds.size.width / 2);
+  const double y = bounds.origin.y + (bounds.size.height / 2);
+  return CGPointMake(x, y);
 }
 
 }


### PR DESCRIPTION
Adds a `GenericMouse` implementation called `QuartzInputMouse` as well as some minor modifications to Dolphin's build instructions that enable building PrimeHack on macOS. I don't have a ton of experience in C++, so hopefully it's a stellar enough implementation. It lifts a lot of code from existing Dolphin interfaces.

Credit to the conversation in #100, which got me on the right track and which this PR should resolve #100.
 

So far I have only tested on two machines:

- M1 Mac mini
- Intel MacBook Pro 2019

Both machines were running macOS 12.4. The minimum build target is macOS 11.0. As such, it should not build on anything running an OS older than macOS Big Sur.

Testing was minimal. I only played though the first bits of _Echoes_ and _Corruption_ on a _Trilogy_ ROM.

I was unable to build a universal binary (i.e., a binary that runs on both M1 and Intel machines). Frankly that process sounds like quite a headache. Hopefully someone could take up that task in the future.

It should be noted that the optimal performance settings described in PrimeHack's Wiki do not apply to macOS, or at least the M1 hardware I tested on. In particular, turning off **Synchronize GPU thread** led to constant crashes. YMMV, of course.

The only change that I believe has any chance of affecting non-macOS builds is at `Source/Core/DolphinQt/CMakeLists.txt`. Following advice from [this thread](https://bugs.dolphin-emu.org/issues/11332), I removed some lines from build instructions on Apple devices that seemed to link multiple versions of Qt. It shouldn't affect any other platforms, but I have not tested it on non-Apple devices to confirm.
