### PR TITLE
Fix MacOS Build - Qt and OSX/MacOS targets

### DIFF
--- a/BuildMacOSUniversalBinary.py
+++ b/BuildMacOSUniversalBinary.py
@@ -64,7 +64,7 @@ DEFAULT_CONFIG = {
 
     # Minimum macOS version for each architecture slice
     "arm64_mac_os_deployment_target":  "11.0.0",
-    "x86_64_mac_os_deployment_target": "10.14.0",
+    "x86_64_mac_os_deployment_target": "10.15.0",
 
     # CMake Generator to use for building
     "generator": "Unix Makefiles",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 # Minimum OS X version.
 # This is inserted into the Info.plist as well.
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14.0" CACHE STRING "")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15.0" CACHE STRING "")
 
 set(CMAKE_USER_MAKE_RULES_OVERRIDE "CMake/FlagsOverride.cmake")
 

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -17,7 +17,11 @@ set(CMAKE_AUTOMOC ON)
 # When Qt5 and Qt6 are given in same NAMES entry, only Qt5 is ever found.
 # find_package(QT NAMES Qt6 COMPONENTS Core Gui Widgets)
 # if(NOT QT_DIR)
-find_package(QT NAMES Qt5 COMPONENTS Core Gui Widgets)
+if (UNIX AND NOT APPLE)
+  find_package(QT NAMES Qt5 COMPONENTS Core Gui Widgets)
+else()
+  find_package(QT NAMES Qt6 COMPONENTS Core Gui Widgets)
+endif()
 # endif()
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Widgets)
 message(STATUS "Found Qt version ${QT_VERSION}")
@@ -663,12 +667,12 @@ if(APPLE)
     add_custom_command(TARGET dolphin-emu
       POST_BUILD COMMAND
       /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY}" --deep --options=runtime --entitlements "${CMAKE_SOURCE_DIR}/Source/Core/DolphinQt/DolphinEmu$<$<CONFIG:Debug>:Debug>.entitlements" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Dolphin.app" || true)
-    
+
     # Code sign builds for build systems that do have release/debug variants (Xcode)
     add_custom_command(TARGET dolphin-emu
       POST_BUILD COMMAND
       /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY}" --deep --options=runtime --entitlements "${CMAKE_SOURCE_DIR}/Source/Core/DolphinQt/DolphinEmuDebug.entitlements" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG}/Dolphin.app" || true)
-      
+
     add_custom_command(TARGET dolphin-emu
       POST_BUILD COMMAND
       /usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY}" --deep --options=runtime --entitlements "${CMAKE_SOURCE_DIR}/Source/Core/DolphinQt/DolphinEmu.entitlements" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE}/Dolphin.app" || true)


### PR DESCRIPTION
- Added OS check to avoid issues with cmake attempting top use the wrong version of Qt for the host OS (Qt5 for Linux, Qt6 for MacOS).
- Increased OSX target to 10.15.0 for _CMakeLists.txt_ and _BuildMacOSUniversalBinary.py_