### PR TITLE
CI: Add GitHub Actions mac build

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -1,0 +1,157 @@
+name: MacOS Build Steps
+
+on: [push, pull_request]
+
+jobs:
+  build_macos:
+    name: macOS Build
+    runs-on: macos-11.0
+    env:
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_COMPRESS: true
+      CCACHE_COMPRESSLEVEL: 9
+      CCACHE_MAXSIZE: 200M
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Packages
+        env:
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
+          HOMEBREW_NO_ANALYTICS: 1
+        run: |
+          if ! brew install ccache; then
+            brew update
+            brew install ccache
+          fi
+
+      - name: Cache Dependencies
+        id: cache-deps
+        uses: actions/cache@v3
+        with:
+          path: ~/deps
+          key: macOS deps ${{ hashFiles('.github/workflows/scripts/macos/build-dependencies.sh') }}
+
+      - name: Build Dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: .github/workflows/scripts/macos/build-dependencies.sh
+
+      - name: Cache MoltenVK
+        id: cache-moltenvk
+        uses: actions/cache@v3
+        with:
+          path: ~/moltenvk
+          key: macOS MoltenVK ${{ hashFiles('Externals/MoltenVK') }}
+
+      - name: Build MoltenVK
+        if: steps.cache-moltenvk.outputs.cache-hit != 'true'
+        run: |
+          MVK_VER="$(sed -nr 's/^.*set\(MOLTENVK_VERSION "([^"]+)".*$/\1/p' Externals/MoltenVK/CMakeLists.txt)"
+          if [ -z "$MVK_VER" ]; then
+            echo "::error::Failed to parse MoltenVK version from CMakeLists"
+            exit 1
+          fi
+          git clone --depth 1 --branch "$MVK_VER" https://github.com/KhronosGroup/MoltenVK.git mvk-build
+          pushd mvk-build
+          git apply ../Externals/MoltenVK/patches/*.patch
+          ./fetchDependencies --macos
+          make macos
+          chmod 755 Package/Release/MoltenVK/dylib/macOS/libMoltenVK.dylib
+          mkdir -p "$HOME/moltenvk/lib/"
+          mv Package/Release/MoltenVK/dylib/macOS/libMoltenVK.dylib "$HOME/moltenvk/lib/"
+          popd
+          rm -rf mvk-build
+
+      # -- SETUP CCACHE - https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        run: echo "timestamp=$(date -u "+%Y-%m-%d-%H;%M;%S")" >> $GITHUB_OUTPUT
+
+      - name: Cache ccache cache
+        uses: actions/cache@v3
+        with:
+          path: .ccache
+          key: macOS ccache ${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: macOS ccache
+
+      - name: Generate CMake Files
+        run: |
+          cmake -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+                -DCMAKE_SYSTEM_PROCESSOR=x86_64 \
+                -DCMAKE_SYSTEM_NAME=Darwin \
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 \
+                -DCMAKE_PREFIX_PATH="$HOME/deps;$HOME/moltenvk" \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DUSE_BUNDLED_MOLTENVK=OFF \
+                -DMACOS_CODE_SIGNING=OFF \
+                -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+                -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON \
+                -B build .
+          cmake -DCMAKE_OSX_ARCHITECTURES=arm64 \
+                -DCMAKE_SYSTEM_PROCESSOR=arm64 \
+                -DCMAKE_SYSTEM_NAME=Darwin \
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
+                -DCMAKE_PREFIX_PATH="$HOME/deps;$HOME/moltenvk" \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DUSE_BUNDLED_MOLTENVK=OFF \
+                -DMACOS_CODE_SIGNING=OFF \
+                -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+                -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON \
+                -B build-arm .
+
+      - name: Build Dolphin (x86_64)
+        working-directory: build
+        run: |
+          ccache -p
+          ccache -s
+          ccache -z
+          make -j$(getconf _NPROCESSORS_ONLN) dolphin-emu
+          ccache -s
+
+      - name: Build Dolphin (arm64)
+        working-directory: build-arm
+        run: |
+          ccache -p
+          ccache -s
+          ccache -z
+          make -j$(getconf _NPROCESSORS_ONLN) dolphin-emu
+          ccache -s
+
+      - name: Prepare Build Artifacts
+        id: create-artifact
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          lipo -create build/Binaries/Dolphin.app/Contents/MacOS/Dolphin build-arm/Binaries/Dolphin.app/Contents/MacOS/Dolphin -o dolphin
+          mv dolphin build/Binaries/Dolphin.app/Contents/MacOS/Dolphin
+          TAG="$(git tag --points-at HEAD)"
+          if [ ! -z "$TAG" ]; then
+            SUFFIX="$TAG"
+          elif [ "$EVENT_NAME" == "pull_request" ]; then
+            PR_TITLE=$(echo "${PR_TITLE}" | tr -cd '[a-zA-Z0-9[:space:]]_-')
+            SUFFIX="pr[$PR_NUM]-sha[$PR_SHA]-title[$PR_TITLE"
+            SUFFIX=$(printf "%.99s]" "$SUFFIX")
+          else
+            SUFFIX="sha[$(git rev-parse --short HEAD)]"
+          fi
+          APPNAME="PrimeHack-$SUFFIX"
+          mv build/Binaries/Dolphin.app "$APPNAME.app"
+          tar cvzf "$APPNAME.tar.gz" "$APPNAME.app"
+          echo "name=$APPNAME" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.create-artifact.outputs.name }}
+          path: "*.tar.gz"

--- a/.github/workflows/scripts/macos/build-dependencies.sh
+++ b/.github/workflows/scripts/macos/build-dependencies.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -e
+
+export MACOSX_DEPLOYMENT_TARGET=10.15
+INSTALLDIR="$HOME/deps"
+NPROCS="$(getconf _NPROCESSORS_ONLN)"
+SDL=SDL2-2.26.0
+QT=6.2.4
+
+mkdir deps-build
+cd deps-build
+
+export PKG_CONFIG_PATH="$INSTALLDIR/lib/pkgconfig:$PKG_CONFIG_PATH"
+export LDFLAGS="-L$INSTALLDIR/lib -dead_strip $LDFLAGS"
+export CFLAGS="-I$INSTALLDIR/include -Os $CFLAGS"
+export CXXFLAGS="-I$INSTALLDIR/include -Os $CXXFLAGS"
+
+cat > SHASUMS <<EOF
+8000d7169febce93c84b6bdf376631f8179132fd69f7015d4dadb8b9c2bdb295  $SDL.tar.gz
+d9924d6fd4fa5f8e24458c87f73ef3dfc1e7c9b877a5407c040d89e6736e2634  qtbase-everywhere-src-$QT.tar.xz
+17f40689c4a1706a1b7db22fa92f6ab79f7b698a89e100cab4d10e19335f8267  qttools-everywhere-src-$QT.tar.xz
+bd1aac74a892c60b2f147b6d53bb5b55ab7a6409e63097d38198933f8024fa51  qttranslations-everywhere-src-$QT.tar.xz
+EOF
+
+curl -L \
+	-O "https://libsdl.org/release/$SDL.tar.gz" \
+	-O "https://download.qt.io/official_releases/qt/${QT%.*}/$QT/submodules/qtbase-everywhere-src-$QT.tar.xz" \
+	-O "https://download.qt.io/official_releases/qt/${QT%.*}/$QT/submodules/qttools-everywhere-src-$QT.tar.xz" \
+	-O "https://download.qt.io/official_releases/qt/${QT%.*}/$QT/submodules/qttranslations-everywhere-src-$QT.tar.xz" \
+
+shasum -a 256 --check SHASUMS
+
+echo "Installing SDL..."
+tar xf "$SDL.tar.gz"
+cd "$SDL"
+CC="clang -arch x86_64 -arch arm64" ./configure --prefix "$INSTALLDIR" --without-x
+make "-j$NPROCS"
+make install
+cd ..
+
+echo "Installing Qt Base..."
+tar xf "qtbase-everywhere-src-$QT.tar.xz"
+cd "qtbase-everywhere-src-$QT"
+cmake -B build -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DCMAKE_PREFIX_PATH="$INSTALLDIR" -DCMAKE_INSTALL_PREFIX="$INSTALLDIR" -DCMAKE_BUILD_TYPE=Release -DFEATURE_optimize_size=ON -DFEATURE_dbus=OFF -DFEATURE_framework=OFF -DFEATURE_icu=OFF -DFEATURE_opengl=OFF -DFEATURE_printsupport=OFF -DFEATURE_sql=OFF -DFEATURE_gssapi=OFF -DFEATURE_system_png=OFF -DFEATURE_system_jpeg=OFF -DCMAKE_MESSAGE_LOG_LEVEL=STATUS
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+
+echo "Installing Qt Tools..."
+tar xf "qttools-everywhere-src-$QT.tar.xz"
+cd "qttools-everywhere-src-$QT"
+# Linguist relies on a library in the Designer target, which takes 5-7 minutes to build on the CI
+# Avoid it by not building Linguist, since we only need the tools that come with it
+patch -u src/linguist/CMakeLists.txt <<EOF
+--- src/linguist/CMakeLists.txt
++++ src/linguist/CMakeLists.txt
+@@ -14,7 +14,7 @@
+ add_subdirectory(lrelease-pro)
+ add_subdirectory(lupdate)
+ add_subdirectory(lupdate-pro)
+-if(QT_FEATURE_process AND QT_FEATURE_pushbutton AND QT_FEATURE_toolbutton AND TARGET Qt::Widgets AND NOT no-png)
++if(QT_FEATURE_process AND QT_FEATURE_pushbutton AND QT_FEATURE_toolbutton AND TARGET Qt::Widgets AND TARGET Qt::PrintSupport AND NOT no-png)
+     add_subdirectory(linguist)
+ endif()
+EOF
+cmake -B build -DCMAKE_PREFIX_PATH="$INSTALLDIR" -DCMAKE_INSTALL_PREFIX="$INSTALLDIR" -DCMAKE_BUILD_TYPE=Release -DFEATURE_assistant=OFF -DFEATURE_clang=OFF -DFEATURE_designer=OFF -DFEATURE_kmap2qmap=OFF -DFEATURE_pixeltool=OFF -DFEATURE_pkg_config=OFF -DFEATURE_qev=OFF -DFEATURE_qtattributionsscanner=OFF -DFEATURE_qtdiag=OFF -DFEATURE_qtplugininfo=OFF
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+
+echo "Installing Qt Translations..."
+tar xf "qttranslations-everywhere-src-$QT.tar.xz"
+cd "qttranslations-everywhere-src-$QT"
+cmake -B build -DCMAKE_PREFIX_PATH="$INSTALLDIR" -DCMAKE_INSTALL_PREFIX="$INSTALLDIR" -DCMAKE_BUILD_TYPE=Release
+make -C build "-j$NPROCS"
+make -C build install
+cd ..
+
+echo "Cleaning up..."
+cd ..
+rm -r deps-build


### PR DESCRIPTION
I heard Mac builds were wanted

Uses GitHub Actions CI for infinite Mac builds.  You can download the artifacts and post them wherever.

Initial build will take like 2 hours, but builds with warm caches should take around 15 minutes, which isn't too bad.    

Recommendation: Unzip the outer zip layer and post the `.tar.gz` inside.  GHActions buries all artifacts in a zip, even if they were already one file, not much we can do about it.  Also, builds from tagged commits will have the nicest looking names, so use those if possible.