### PR TITLE
Fix "error: no viable conversion"

### DIFF
--- a/Source/Core/InputCommon/XInput2Mouse.cpp
+++ b/Source/Core/InputCommon/XInput2Mouse.cpp
@@ -33,7 +33,7 @@ bool InitXInput2Mouse(void* const hwnd)
   current_master = &all_masters[0];
   if (current_master->use == XIMasterPointer)
   {
-    g_mouse_input.reset(XInput2Mouse((Window)hwnd, xi_opcode, current_master->deviceid));
+    g_mouse_input.reset(new XInput2Mouse((Window)hwnd, xi_opcode, current_master->deviceid));
   }
 
   XCloseDisplay(dpy);


### PR DESCRIPTION
Fixes #165.

Typo in e763a70f14f76c9364765fe32e6ebe50ff9b423e causes following error:

```
dolphin-emu-primehack/Source/Core/InputCommon/XInput2Mouse.cpp:36:25: error: no viable conversion from 'XInput2Mouse' to 'pointer' (aka 'prime::GenericMouse *')
   36 |     g_mouse_input.reset(XInput2Mouse((Window)hwnd, xi_opcode, current_master->deviceid));
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/unique_ptr.h:505:21: note: passing argument to parameter '__p' here
  505 |       reset(pointer __p = pointer()) noexcept
      |                     ^
1 error generated.
```


