### PR TITLE
Fixing ball_state memory address in MP2 Trilogy.

### DIFF
--- a/Source/Core/Core/PrimeHack/AddressDBInit.cpp
+++ b/Source/Core/Core/PrimeHack/AddressDBInit.cpp
@@ -149,7 +149,7 @@ void init_db(AddressDB& addr_db) {
   addr_db.register_dynamic_address(Game::PRIME_2, "angular_momentum", "player", {mrt1(0x178)});
   addr_db.register_dynamic_address(Game::PRIME_2, "firstperson_pitch", "player", {mrt1(0x5f0)});
   addr_db.register_dynamic_address(Game::PRIME_2, "armcannon_matrix", "player", {mrt1(0xea8), mrt1(0x3b0)});
-  addr_db.register_dynamic_address(Game::PRIME_2, "ball_state", "player", {mrt1(0x374)});
+  addr_db.register_dynamic_address(Game::PRIME_2, "ball_state", "player", {mrt1(0x378)});
   addr_db.register_dynamic_address(Game::PRIME_2, "powerups_array", "player", {mrt1(0x12ec), rt0});
   addr_db.register_dynamic_address(Game::PRIME_2, "active_visor", "powerups_array", {mrt1(0x34)});
   addr_db.register_dynamic_address(Game::PRIME_2, "world_id", "world_id_ptr", {rt0, rt0});

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj.user
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj.user
@@ -5,4 +5,7 @@
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <ShowAllFiles>true</ShowAllFiles>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LocalDebuggerCommandArguments>-d</LocalDebuggerCommandArguments>
+  </PropertyGroup>
 </Project>

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj.user
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj.user
@@ -5,7 +5,4 @@
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <ShowAllFiles>true</ShowAllFiles>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>-d</LocalDebuggerCommandArguments>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
After searching for the screw attack memory address I found that the address of ball_state seems to be off by 4. I did this search on a Pal version of the trilogy and the NA version. I checked Prime_2_GCN on an NA version and found no issue with it's addresses.