### PR TITLE
screw attack use main profile

### DIFF
--- a/Source/Core/Core/PrimeHack/AddressDBInit.cpp
+++ b/Source/Core/Core/PrimeHack/AddressDBInit.cpp
@@ -150,6 +150,7 @@ void init_db(AddressDB& addr_db) {
   addr_db.register_dynamic_address(Game::PRIME_2, "firstperson_pitch", "player", {mrt1(0x5f0)});
   addr_db.register_dynamic_address(Game::PRIME_2, "armcannon_matrix", "player", {mrt1(0xea8), mrt1(0x3b0)});
   addr_db.register_dynamic_address(Game::PRIME_2, "ball_state", "player", {mrt1(0x378)});
+  addr_db.register_dynamic_address(Game::PRIME_2, "screw_state", "player", {mrt1(0x37c)});
   addr_db.register_dynamic_address(Game::PRIME_2, "powerups_array", "player", {mrt1(0x12ec), rt0});
   addr_db.register_dynamic_address(Game::PRIME_2, "active_visor", "powerups_array", {mrt1(0x34)});
   addr_db.register_dynamic_address(Game::PRIME_2, "world_id", "world_id_ptr", {rt0, rt0});
@@ -177,6 +178,7 @@ void init_db(AddressDB& addr_db) {
   addr_db.register_dynamic_address(Game::PRIME_2_GCN, "orbit_state", "player", {mrt1(0x3a4)});
   addr_db.register_dynamic_address(Game::PRIME_2_GCN, "firstperson_pitch", "player", {mrt1(0x604)});
   addr_db.register_dynamic_address(Game::PRIME_2_GCN, "ball_state", "player", {mrt1(0x38c)});
+  addr_db.register_dynamic_address(Game::PRIME_2_GCN, "screw_state", "player", {mrt1(0x390)});
   addr_db.register_dynamic_address(Game::PRIME_2_GCN, "angular_vel", "player", {mrt1(0x1bc)});
   addr_db.register_dynamic_address(Game::PRIME_2_GCN, "world_id", "world", {mrt1(0x8)});
   addr_db.register_dynamic_address(Game::PRIME_2_GCN, "area_id", "state_manager", {mrt1(0x16a0)});
@@ -210,6 +212,7 @@ void init_db(AddressDB& addr_db) {
   addr_db.register_dynamic_address(Game::PRIME_3, "beamvisor_menu_state", "beamvisor_menu_base", {rt0, mrt1(0x300)});
   addr_db.register_dynamic_address(Game::PRIME_3, "angular_momentum", "player", {mrt1(0x174)});
   addr_db.register_dynamic_address(Game::PRIME_3, "ball_state", "player", {mrt1(0x358)});
+  addr_db.register_dynamic_address(Game::PRIME_3, "screw_state", "player", {mrt1(0x35c)});
   addr_db.register_dynamic_address(Game::PRIME_3, "lockon_type", "player", {mrt1(0x370)});
   addr_db.register_dynamic_address(Game::PRIME_3, "audio_manager", "state_manager", {mrt1(0x250), rt0});
   addr_db.register_dynamic_address(Game::PRIME_3, "audio_fadein_time", "audio_manager", {mrt1(0x308)});
@@ -242,6 +245,7 @@ void init_db(AddressDB& addr_db) {
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "active_visor", "powerups_array", {mrt1(0x34)});
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "angular_momentum", "player", {mrt1(0x174)});
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "ball_state", "player", {mrt1(0x358)});
+  addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "screw_state", "player", {mrt1(0x35c)});
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "lockon_type", "player", {mrt1(0x370)});
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "audio_manager", "state_manager", {mrt1(0x250), rt0});
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "audio_fadein_time", "audio_manager", {mrt1(0x308)});

--- a/Source/Core/Core/PrimeHack/AddressDBInit.cpp
+++ b/Source/Core/Core/PrimeHack/AddressDBInit.cpp
@@ -149,7 +149,7 @@ void init_db(AddressDB& addr_db) {
   addr_db.register_dynamic_address(Game::PRIME_2, "angular_momentum", "player", {mrt1(0x178)});
   addr_db.register_dynamic_address(Game::PRIME_2, "firstperson_pitch", "player", {mrt1(0x5f0)});
   addr_db.register_dynamic_address(Game::PRIME_2, "armcannon_matrix", "player", {mrt1(0xea8), mrt1(0x3b0)});
-  addr_db.register_dynamic_address(Game::PRIME_2, "ball_state", "player", {mrt1(0x374)});
+  addr_db.register_dynamic_address(Game::PRIME_2, "ball_state", "player", {mrt1(0x378)});
   addr_db.register_dynamic_address(Game::PRIME_2, "powerups_array", "player", {mrt1(0x12ec), rt0});
   addr_db.register_dynamic_address(Game::PRIME_2, "active_visor", "powerups_array", {mrt1(0x34)});
   addr_db.register_dynamic_address(Game::PRIME_2, "world_id", "world_id_ptr", {rt0, rt0});

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
@@ -357,7 +357,7 @@ void FpsControls::run_mod_mp1(Region region) {
     }
 
     LOOKUP_DYN(menu_state);
-    swap_alt_profiles(read32(ball_state), read32(menu_state));
+    swap_alt_profiles(read32(ball_state), read32(menu_state), 0);
   }
 }
 
@@ -518,7 +518,8 @@ void FpsControls::run_mod_mp2(Region region) {
     write32(0, angular_momentum + 0x18);
 
     LOOKUP_DYN(menu_state);
-    swap_alt_profiles(read32(ball_state), read32(menu_state));
+    LOOKUP_DYN(screw_state);
+    swap_alt_profiles(read32(ball_state), read32(menu_state), read32(screw_state));
   }
 }
 
@@ -699,8 +700,9 @@ void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
   LOOKUP(state_manager);
   LOOKUP_DYN(ball_state);
   LOOKUP_DYN(menu_state);
+  LOOKUP_DYN(screw_state);
 
-  swap_alt_profiles(read32(ball_state), read32(menu_state));
+  swap_alt_profiles(read32(ball_state), read32(menu_state), read32(screw_state));
 
   // Handles menu screen cursor
   LOOKUP(cursor_dlg_enabled);
@@ -827,7 +829,7 @@ void FpsControls::CheckBeamVisorSetting(Game game)
 }
 
 bool FpsControls::init_mod(Game game, Region region) {
-  swap_alt_profiles(0, 0);
+  swap_alt_profiles(0, 0, 0);
 
   switch (game) {
   case Game::MENU_PRIME_1:

--- a/Source/Core/Core/PrimeHack/PrimeUtils.cpp
+++ b/Source/Core/Core/PrimeHack/PrimeUtils.cpp
@@ -160,10 +160,13 @@ int get_beam_switch(std::array<int, 4> const& beams) {
   return -1;
 }
 
-void swap_alt_profiles(u32 ball_state, u32 transition_state)
+void swap_alt_profiles(u32 ball_state, u32 transition_state, u32 screw_state)
 {
-  /* Ball State 1 - Morphed, Transition State 1 - Map */
-  if ((ball_state == 1 || ball_state == 2 || transition_state == 1) && !was_in_alternate)
+  /* Ball State 1 & Screw State 0 - Morphed, Transition State 1 - Map, Screw State 1 - Screw Attack */
+  const bool morphed = (ball_state == 1 || ball_state == 2 || ball_state == 3) && (screw_state == 0);
+  const bool in_map = (transition_state == 1);
+
+  if ((morphed || in_map) && !was_in_alternate)
   {
     std::string profile = GetProfiles().first;
 
@@ -172,7 +175,7 @@ void swap_alt_profiles(u32 ball_state, u32 transition_state)
     }
     was_in_alternate = true;
   }
-  else if ((ball_state == 0 && transition_state != 1) && was_in_alternate)
+  else if (!(morphed || in_map) && was_in_alternate)
   {
     std::string profile = GetProfiles().second;
 

--- a/Source/Core/Core/PrimeHack/PrimeUtils.h
+++ b/Source/Core/Core/PrimeHack/PrimeUtils.h
@@ -49,7 +49,7 @@ void set_beam_owned(int index, bool owned);
 void set_visor_owned(int index, bool owned);
 void set_cursor_pos(float x, float y);
 
-void swap_alt_profiles(u32 ball_state, u32 transition_state);
+void swap_alt_profiles(u32 ball_state, u32 transition_state, u32 screw_state);
 
 void DevInfo(const char* name, const char* format, ...);
 void DevInfoMatrix(const char* name, const Transform& t);

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj.user
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj.user
@@ -5,4 +5,7 @@
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <ShowAllFiles>true</ShowAllFiles>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LocalDebuggerCommandArguments>-d</LocalDebuggerCommandArguments>
+  </PropertyGroup>
 </Project>

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj.user
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj.user
@@ -5,7 +5,4 @@
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <ShowAllFiles>true</ShowAllFiles>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>-d</LocalDebuggerCommandArguments>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This fixes issue #106 by making screw attack use the main profile, instead of the morph profile.