### PR TITLE
Fix/gc sync yaw pitch

### DIFF
--- a/Source/Core/Core/PrimeHack/AddressDBInit.cpp
+++ b/Source/Core/Core/PrimeHack/AddressDBInit.cpp
@@ -176,6 +176,7 @@ void init_db(AddressDB& addr_db) {
   addr_db.register_dynamic_address(Game::PRIME_2_GCN, "player_xf", "player", {mrt1(0x24)});
   addr_db.register_dynamic_address(Game::PRIME_2_GCN, "orbit_state", "player", {mrt1(0x3a4)});
   addr_db.register_dynamic_address(Game::PRIME_2_GCN, "firstperson_pitch", "player", {mrt1(0x604)});
+  addr_db.register_dynamic_address(Game::PRIME_2_GCN, "camera_state", "player", {mrt1(0x388)});
   addr_db.register_dynamic_address(Game::PRIME_2_GCN, "ball_state", "player", {mrt1(0x38c)});
   addr_db.register_dynamic_address(Game::PRIME_2_GCN, "angular_vel", "player", {mrt1(0x1bc)});
   addr_db.register_dynamic_address(Game::PRIME_2_GCN, "world_id", "world", {mrt1(0x8)});

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
@@ -397,6 +397,7 @@ void FpsControls::run_mod_mp1_gc(Region region) {
   if (read32(camera_state) != 0) {
     vec3 fwd = cplayer_xf.fwd();
     yaw = atan2f(fwd.y, fwd.x);
+    pitch = atan2f(fwd.z, sqrtf(fwd.x * fwd.x + fwd.y * fwd.y));
     return;
   }
 

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
@@ -572,6 +572,15 @@ void FpsControls::run_mod_mp2_gc(Region region) {
     return;
   }
 
+  LOOKUP_DYN(camera_state);
+  if (read32(camera_state) != 0)
+  {
+    vec3 fwd = cplayer_xf.fwd();
+    yaw = atan2f(fwd.y, fwd.x);
+    pitch = atan2f(fwd.z, sqrtf(fwd.x * fwd.x + fwd.y * fwd.y));
+    return;
+  }
+
   LOOKUP(tweak_player_offset);
   const u32 tweak_player_address = read32(read32(Core::System::GetInstance().GetPPCState().gpr[13] + tweak_player_offset));
   if (mem_check(tweak_player_address)) {
@@ -587,13 +596,11 @@ void FpsControls::run_mod_mp2_gc(Region region) {
     }
   }
 
-  LOOKUP_DYN(ball_state);
-  if (read32(ball_state) == 0) {
-    calculate_pitchyaw_delta();
-    writef32(FpsControls::pitch, firstperson_pitch);
-    cplayer_xf.build_rotation(yaw);
-    cplayer_xf.write_to(*active_guard, player_xf);
-  }
+  calculate_pitchyaw_delta();
+  writef32(FpsControls::pitch, firstperson_pitch);
+  cplayer_xf.build_rotation(yaw);
+  cplayer_xf.write_to(*active_guard, player_xf);
+
 }
 
 void FpsControls::mp3_handle_lasso(u32 grapple_state_addr) {

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
@@ -573,13 +573,25 @@ void FpsControls::run_mod_mp2_gc(Region region) {
   }
 
   LOOKUP_DYN(camera_state);
-  if (read32(camera_state) != 0)
+  const u32 cam_state = read32(camera_state);
+  static u32 prev_cam_state = 0;
+
+  const bool camera_is_controlled_by_game = (cam_state != 0);
+  const bool camera_was_controlled_by_game_last_frame = (prev_cam_state != 0 && cam_state == 0); // necessary to display the correct view after cutscene ends.
+  const bool sync_view_from_camera = camera_is_controlled_by_game || camera_was_controlled_by_game_last_frame;
+
+  if (sync_view_from_camera)
   {
     vec3 fwd = cplayer_xf.fwd();
     yaw = atan2f(fwd.y, fwd.x);
     pitch = atan2f(fwd.z, sqrtf(fwd.x * fwd.x + fwd.y * fwd.y));
+  }
+  if (camera_is_controlled_by_game)
+  {
+    prev_cam_state = cam_state;
     return;
   }
+  prev_cam_state = cam_state;
 
   LOOKUP(tweak_player_offset);
   const u32 tweak_player_address = read32(read32(Core::System::GetInstance().GetPPCState().gpr[13] + tweak_player_offset));


### PR DESCRIPTION
When the game temporarily owns the camera (morph ball, cutscenes), PrimeHack continued to use stale yaw/pitch state for the GameCube versions of Prime 1 and 2. This caused the view to snap or point in the wrong direction when FPS control resumed.