### PR TITLE
Add raw Gyro input for additional camera controls

### DIFF
--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -78,81 +78,100 @@ bool GetMicButton(const int pad_num)
   return static_cast<GCPad*>(s_config.GetController(pad_num))->GetMicButton();
 }
 
-void ChangeUIPrimeHack(int number, bool useMetroidUI)
+void ChangeUIPrimeHack(int pad_num, bool useMetroidUI)
 {
-  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(number));
+  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(pad_num));
 
   gcpad->ChangeUIPrimeHack(useMetroidUI);
 }
 
-bool CheckSpringBall()
+bool CheckSpringBall(int pad_num)
 {
-  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(0));
+  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(pad_num));
 
   return gcpad->CheckSpringBallCtrl();
 }
 
-bool CheckPitchRecentre()
+bool CheckPitchRecentre(int pad_num)
 {
-  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(0));
+  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(pad_num));
 
   return gcpad->CheckPitchRecentre();
 }
 
-bool PrimeUseController()
+bool PrimeUseController(int pad_num)
 {
-  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(0));
+  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(pad_num));
 
   return gcpad->PrimeControllerMode();
 }
 
-void PrimeSetMode(bool useController)
+void PrimeSetMode(int pad_num, bool useController)
 {
-  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(0));
+  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(pad_num));
 
   gcpad->SetPrimeMode(useController);
 }
 
-std::tuple<double, double> GetPrimeStickXY()
+bool PrimeUseGyro(int pad_num)
 {
-  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(0));
+  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(pad_num));
+
+  return gcpad->PrimeUseGyro();
+}
+
+std::tuple<double, double> GetPrimeStickXY(int pad_num)
+{
+  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(pad_num));
 
   return gcpad->GetPrimeStickXY();
 }
 
-bool CheckForward() {
-  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(0));
+std::tuple<double, double> GetPrimeGyroPitchYaw(int pad_num)
+{
+  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(pad_num));
+
+  return gcpad->GetPrimeGyroPitchYaw();
+}
+
+bool CheckForward(int pad_num)
+{
+  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(pad_num));
 
   return gcpad->groups[1]->controls[0].get()->control_ref->State() > 0.5;
 }
 
-bool CheckBack() {
-  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(0));
+bool CheckBack(int pad_num)
+{
+  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(pad_num));
 
   return gcpad->groups[1]->controls[1].get()->control_ref->State() > 0.5;
 }
 
-bool CheckLeft() {
-  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(0));
+bool CheckLeft(int pad_num)
+{
+  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(pad_num));
 
   return gcpad->groups[1]->controls[2].get()->control_ref->State() > 0.5;
 }
 
-bool CheckRight() {
-  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(0));
+bool CheckRight(int pad_num)
+{
+  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(pad_num));
 
   return gcpad->groups[1]->controls[3].get()->control_ref->State() > 0.5;
 }
 
-bool CheckJump() {
-  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(0));
+bool CheckJump(int pad_num)
+{
+  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(pad_num));
 
   return gcpad->groups[0]->controls[1]->control_ref->State() > 0.5;
 }
 
-std::tuple<double, double, bool, bool, bool> PrimeSettings()
+std::tuple<double, double, bool, bool, bool> PrimeSettings(int pad_num)
 {
-  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(0));
+  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(pad_num));
 
   return gcpad->GetPrimeSettings();
 }

--- a/Source/Core/Core/HW/GCPad.h
+++ b/Source/Core/Core/HW/GCPad.h
@@ -32,21 +32,24 @@ void ResetRumble(int pad_num);
 
 bool GetMicButton(int pad_num);
 
-void ChangeUIPrimeHack(int number, bool useMetroidUI);
+void ChangeUIPrimeHack(int pad_num, bool useMetroidUI);
 
-bool CheckSpringBall();
-bool CheckPitchRecentre();
-bool PrimeUseController();
+bool CheckSpringBall(int pad_num);
+bool CheckPitchRecentre(int pad_num);
+bool PrimeUseController(int pad_num);
 
-void PrimeSetMode(bool controller);
+void PrimeSetMode(int pad_num, bool controller);
 
-bool CheckForward();
-bool CheckBack();
-bool CheckLeft();
-bool CheckRight();
-bool CheckJump();
+bool PrimeUseGyro(int pad_num);
 
-std::tuple<double, double> GetPrimeStickXY();
+bool CheckForward(int pad_num);
+bool CheckBack(int pad_num);
+bool CheckLeft(int pad_num);
+bool CheckRight(int pad_num);
+bool CheckJump(int pad_num);
 
-std::tuple<double, double, bool, bool, bool> PrimeSettings();
+std::tuple<double, double> GetPrimeStickXY(int pad_num);
+std::tuple<double, double> GetPrimeGyroPitchYaw(int pad_num);
+
+std::tuple<double, double, bool, bool, bool> PrimeSettings(int pad_num);
 }  // namespace Pad

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -12,6 +12,7 @@
 
 #include "InputCommon/ControllerEmu/Control/Input.h"
 #include "InputCommon/ControllerEmu/ControlGroup/AnalogStick.h"
+#include "InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.h"
 #include "InputCommon/ControllerEmu/ControlGroup/Buttons.h"
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerEmu/ControlGroup/MixedTriggers.h"
@@ -37,21 +38,6 @@ static const u16 dpad_bitmasks[] = {PAD_BUTTON_UP, PAD_BUTTON_DOWN, PAD_BUTTON_L
                                     PAD_BUTTON_RIGHT};
 static const u8 triforce_bitmask[] = {SWITCH_TEST, SWITCH_SERVICE, SWITCH_COIN};
 
-static const char* const named_buttons[] = {"A", "B", "X", "Y", "Z", "Start"};
-static const char* const metroid_named_buttons[] = { "Shoot / Select", "Jump / Cancel", "Morph Ball", "Missile", "Map", "Menu / Hint" };
-
-static const char* const prime_beams[] = { "Beam 1", "Beam 2", "Beam 3", "Beam 4" };
-static const char* const prime_visors[] = { "Visor 1", "Visor 2", "Visor 3", "Visor 4" };
-
-static const char* const named_triggers[] = {
-    // i18n: The left trigger button (labeled L on real controllers)
-    _trans("L"),
-    // i18n: The right trigger button (labeled R on real controllers)
-    _trans("R"),
-    // i18n: The left trigger button (labeled L on real controllers) used as an analog input
-    _trans("L-Analog"),
-    // i18n: The right trigger button (labeled R on real controllers) used as an analog input
-    _trans("R-Analog")};
 
 GCPad::GCPad(const unsigned int index) : m_index(index)
 {
@@ -131,12 +117,20 @@ GCPad::GCPad(const unsigned int index) : m_index(index)
 );
 
   constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / STICK_RADIUS;
-  groups.emplace_back(m_primehack_stick =
-    new ControllerEmu::OctagonAnalogStick(_trans("Camera Control"), gate_radius));
+  groups.emplace_back(m_primehack_stick = new ControllerEmu::OctagonAnalogStick(
+                          "PrimeHack CameraStick", _trans("Camera Control"), gate_radius));
 
   m_primehack_stick->AddSetting(&m_primehack_horizontal_sensitivity, {"Horizontal Sensitivity", nullptr, nullptr, _trans("Horizontal Sensitivity")}, 45, 1, 100);
   m_primehack_stick->AddSetting(&m_primehack_vertical_sensitivity, {"Vertical Sensitivity", nullptr, nullptr, _trans("Vertical Sensitivity")}, 35, 1, 100);
+  m_primehack_stick->AddSetting(&m_primehack_gyro_enable, {"Enable Gyro", nullptr, nullptr, _trans("Enable Gyro")}, false);
   m_primehack_stick->AddInput(ControllerEmu::Translatability::Translate, _trans("Reset Camera Pitch"));
+
+  groups.emplace_back(m_primehack_gyro = new ControllerEmu::IMUGyroscope(
+                          "PrimeHack CameraGyro", _trans("Gyro Camera")));
+
+  m_primehack_gyro->AddSetting(&m_primehack_gyro_horizontal_sensitivity, {"Horizontal Sensitivity", nullptr, nullptr, _trans("Horizontal Sensitivity")}, 0.45, 0.1, 10.0);
+  m_primehack_gyro->AddSetting(&m_primehack_gyro_vertical_sensitivity, {"Vertical Sensitivity", nullptr, nullptr, _trans("Vertical Sensitivity")}, 0.3, 0.1, 10.0);
+  m_primehack_gyro->AddInput(ControllerEmu::Translatability::Translate, _trans("Activate"));
 
   groups.emplace_back(m_primehack_modes = new ControllerEmu::PrimeHackModes(_trans("PrimeHack")));
 
@@ -186,6 +180,8 @@ ControllerEmu::ControlGroup* GCPad::GetGroup(PadGroup group)
     return m_primehack_stick;
   case PadGroup::Modes:
     return m_primehack_modes;
+  case PadGroup::GyroCamera:
+    return m_primehack_gyro;
   default:
     return nullptr;
   }
@@ -392,12 +388,26 @@ void GCPad::ChangeUIPrimeHack(bool useMetroidUI)
   if (using_metroid_ui == useMetroidUI)
     return;
 
+  constexpr const char* const named_buttons[] = {
+    A_BUTTON, B_BUTTON, X_BUTTON,
+    Y_BUTTON, Z_BUTTON, START_BUTTON
+  };
+
+  constexpr const char* const metroid_named_buttons[] = {
+    _trans("Shoot / Select"), _trans("Jump / Cancel"), _trans("Morph Ball"),
+    _trans("Missile"), _trans("Map"), _trans("Menu / Hint")
+  };
+
+  constexpr const char* const named_triggers[] = {L_DIGITAL, R_DIGITAL, L_ANALOG, R_ANALOG};
+
+  constexpr const char* const prime_beams[] = {_trans("Beam 1"), _trans("Beam 2"), _trans("Beam 3"), _trans("Beam 4")};
+  constexpr const char* const prime_visors[] = {_trans("Visor 1"), _trans("Visor 2"), _trans("Visor 3"), _trans("Visor 4")};
 
   for (int i = 0; i < 6; i++)
   {
     std::string_view ui_name = useMetroidUI ? metroid_named_buttons[i] : named_buttons[i];
 
-    m_buttons->controls[i]->ui_name = _trans(ui_name);
+    m_buttons->controls[i]->ui_name = ui_name;
     m_buttons->controls[i]->display_alt = useMetroidUI;
   }
 
@@ -405,17 +415,17 @@ void GCPad::ChangeUIPrimeHack(bool useMetroidUI)
   {
     std::string_view ui_name = useMetroidUI ? prime_beams[i] : named_directions[i];
 
-    m_c_stick->controls[i]->ui_name = _trans(ui_name);
+    m_c_stick->controls[i]->ui_name = ui_name;
     m_c_stick->controls[i]->display_alt = useMetroidUI;
 
     ui_name = useMetroidUI ? prime_visors[i] : named_directions[i];
 
-    m_dpad->controls[i]->ui_name = _trans(ui_name);
+    m_dpad->controls[i]->ui_name = ui_name;
     m_dpad->controls[i]->display_alt = useMetroidUI;
   }
 
   // Controls both instances in UI for analog feedback and bind text
-  m_triggers->controls[0]->ui_name = useMetroidUI ? "L" : _trans("L");
+  m_triggers->controls[0]->ui_name = useMetroidUI ? _trans("Lock-On") : named_triggers[0];
   m_triggers->controls[0]->display_alt = useMetroidUI;
 
   using_metroid_ui = useMetroidUI;
@@ -436,6 +446,16 @@ std::tuple<double, double> GCPad::GetPrimeStickXY()
   return std::make_tuple(stick_state.x * m_primehack_horizontal_sensitivity.GetValue(), stick_state.y * -m_primehack_vertical_sensitivity.GetValue());
 }
 
+std::tuple<double, double> GCPad::GetPrimeGyroPitchYaw()
+{
+  const auto gyro_state = m_primehack_gyro->GetState().value_or(ControllerEmu::IMUGyroscope::StateData{});
+  const auto gyro_hsens = m_primehack_gyro_horizontal_sensitivity.GetValue() * (360.0 / MathUtil::TAU);
+  const auto gyro_vsens = m_primehack_gyro_vertical_sensitivity.GetValue() * (360.0 / MathUtil::TAU);
+  const auto gyro_act = (double)(m_primehack_gyro->controls[6]->GetState() > 0.5);
+
+  return std::make_tuple(gyro_state.x * gyro_vsens * gyro_act, -gyro_state.z * gyro_hsens * gyro_act);
+}
+
 bool GCPad::CheckPitchRecentre()
 {
   return m_primehack_stick->controls[5]->GetState() > 0.5;
@@ -444,6 +464,11 @@ bool GCPad::CheckPitchRecentre()
 bool GCPad::PrimeControllerMode()
 {
   return m_primehack_modes->GetSelectedDevice() == 1;
+}
+
+bool GCPad::PrimeUseGyro()
+{
+  return m_primehack_gyro_enable.GetValue();
 }
 
 void GCPad::SetPrimeMode(bool controller)

--- a/Source/Core/Core/HW/GCPadEmu.h
+++ b/Source/Core/Core/HW/GCPadEmu.h
@@ -21,6 +21,7 @@ class AnalogStick;
 class Buttons;
 class MixedTriggers;
 class PrimeHackModes;
+class IMUGyroscope;
 }  // namespace ControllerEmu
 
 enum class PadGroup
@@ -40,7 +41,8 @@ enum class PadGroup
   Camera,
   Misc,
   ControlStick,
-  Modes
+  Modes,
+  GyroCamera
 };
 
 class GCPad : public ControllerEmu::EmulatedController
@@ -65,11 +67,13 @@ public:
 
   bool CheckSpringBallCtrl();
   bool PrimeControllerMode();
+  bool PrimeUseGyro();
 
   void SetPrimeMode(bool controller);
 
   bool CheckPitchRecentre();
   std::tuple<double, double> GetPrimeStickXY();
+  std::tuple<double, double> GetPrimeGyroPitchYaw();
 
   std::tuple<double, double, bool, bool, bool> GetPrimeSettings();
 
@@ -127,15 +131,19 @@ private:
   ControllerEmu::ControlGroup* m_primehack_camera;
   ControllerEmu::ControlGroup* m_primehack_misc;
   ControllerEmu::AnalogStick* m_primehack_stick;
+  ControllerEmu::IMUGyroscope* m_primehack_gyro;
   ControllerEmu::PrimeHackModes* m_primehack_modes;
 
   ControllerEmu::SettingValue<double> m_primehack_camera_sensitivity;
   ControllerEmu::SettingValue<double> m_primehack_horizontal_sensitivity;
   ControllerEmu::SettingValue<double> m_primehack_vertical_sensitivity;
+  ControllerEmu::SettingValue<double> m_primehack_gyro_horizontal_sensitivity;
+  ControllerEmu::SettingValue<double> m_primehack_gyro_vertical_sensitivity;
 
   ControllerEmu::SettingValue<bool> m_primehack_invert_y;
   ControllerEmu::SettingValue<bool> m_primehack_invert_x;
   ControllerEmu::SettingValue<bool> m_primehack_remap_map_controls;
+  ControllerEmu::SettingValue<bool> m_primehack_gyro_enable;
 
   static constexpr u8 STICK_GATE_RADIUS = 0x60;
   static constexpr u8 STICK_CENTER = 0x80;

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -239,124 +239,153 @@ void ChangeUIPrimeHack(int number, bool useMetroidUI)
   wiimote->GetNunchuk()->ChangeUIPrimeHack(useMetroidUI);
 }
 
-bool CheckVisor(int visorcount)
+bool CheckVisor(int number, int visorcount)
 {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->CheckVisorCtrl(visorcount);
 }
 
-bool CheckBeam(int beamcount)
+bool CheckBeam(int number, int beamcount)
 {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->CheckBeamCtrl(beamcount);
 }
 
-bool CheckForward() {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+bool CheckForward(int number)
+{
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->GetNunchukGroup(WiimoteEmu::NunchukGroup::Stick)->
       controls[0].get()->control_ref->State() > 0.5;
 }
 
-bool CheckBack() {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+bool CheckBack(int number)
+{
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->GetNunchukGroup(WiimoteEmu::NunchukGroup::Stick)->
       controls[1].get()->control_ref->State() > 0.5;
 }
 
-bool CheckLeft() {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+bool CheckLeft(int number)
+{
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->GetNunchukGroup(WiimoteEmu::NunchukGroup::Stick)->
       controls[2].get()->control_ref->State() > 0.5;
 }
 
-bool CheckRight() {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+bool CheckRight(int number)
+{
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->GetNunchukGroup(WiimoteEmu::NunchukGroup::Stick)->
       controls[3].get()->control_ref->State() > 0.5;
 }
 
-bool CheckJump() {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+bool CheckJump(int number)
+{
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->groups[0].get()->controls[1]->control_ref->State() > 0.5;
 }
 
-bool CheckGrapple() {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+bool CheckGrapple(int number)
+{
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->CheckGrappleCtrl();
 }
 
-bool UseGrappleTapping() {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+bool UseGrappleTapping(int number)
+{
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->CheckUseGrappleTapping();
 }
 
-bool GrappleCtlBound() {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+bool GrappleCtlBound(int number)
+{
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->IsGrappleBinded();
 }
 
-bool CheckSpringBall()
+bool CheckSpringBall(int number)
 {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->CheckSpringBallCtrl();
 }
 
-std::tuple<bool, bool> GetBVMenuOptions()
+std::tuple<bool, bool> GetBVMenuOptions(int number)
 {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->GetBVMenuOptions();
 }
 
-bool CheckImprovedMotions()
+bool CheckImprovedMotions(int number)
 {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->CheckImprovedMotions();
 }
 
-bool CheckVisorScroll(bool direction)
+bool CheckVisorScroll(int number, bool direction)
 {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->CheckVisorScrollCtrl(direction);
 }
 
-bool CheckBeamScroll(bool direction)
+bool CheckBeamScroll(int number, bool direction)
 {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->CheckBeamScrollCtrl(direction);
 }
 
-bool PrimeUseController()
+bool PrimeUseController(int number)
 {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->PrimeControllerMode();
 }
 
-std::tuple<double, double> GetPrimeStickXY()
+void PrimeSetMode(int number, bool controller)
 {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
+
+  wiimote->SetPrimeMode(controller);
+}
+
+bool PrimeUseGyro(int number)
+{
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
+
+  return wiimote->PrimeUseGyro();
+}
+
+std::tuple<double, double> GetPrimeStickXY(int number)
+{
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->GetPrimeStickXY();
 }
 
-std::tuple<double, double, bool, bool, bool, bool, bool> PrimeSettings()
+std::tuple<double, double> GetPrimeGyroPitchYaw(int number)
 {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
+
+  return wiimote->GetPrimeGyroPitchYaw();
+}
+
+std::tuple<double, double, bool, bool, bool, bool, bool> PrimeSettings(int number)
+{
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->GetPrimeSettings();
 }
@@ -366,9 +395,9 @@ WiimoteSource GetSource(unsigned int index)
   return s_wiimote_sources[index];
 }
 
-bool CheckPitchRecentre()
+bool CheckPitchRecentre(int number)
 {
-  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(number));
 
   return wiimote->CheckPitchRecentre();
 }

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -101,30 +101,34 @@ ControllerEmu::ControlGroup* GetShinkansenGroup(int number, WiimoteEmu::Shinkans
 
 void ChangeUIPrimeHack(int number, bool useMetroidUI);
 
-bool CheckVisor(int visor_count);
-bool CheckBeam(int beam_count);
-bool CheckBeamScroll(bool direction);
-bool CheckVisorScroll(bool direction);
-bool CheckSpringBall();
-bool CheckImprovedMotions();
-bool CheckForward();
-bool CheckBack();
-bool CheckLeft();
-bool CheckRight();
-bool CheckJump();
+bool CheckVisor(int number, int visor_count);
+bool CheckBeam(int number, int beam_count);
+bool CheckBeamScroll(int number, bool direction);
+bool CheckVisorScroll(int number, bool direction);
+bool CheckSpringBall(int number);
+bool CheckImprovedMotions(int number);
+bool CheckForward(int number);
+bool CheckBack(int number);
+bool CheckLeft(int number);
+bool CheckRight(int number);
+bool CheckJump(int number);
 
-bool CheckGrapple();
-bool UseGrappleTapping();
-bool GrappleCtlBound();
-bool PrimeUseController();
+bool CheckGrapple(int number);
+bool UseGrappleTapping(int number);
+bool GrappleCtlBound(int number);
+bool PrimeUseController(int number);
 
-bool PrimeUseController();
-bool CheckPitchRecentre();
+void PrimeSetMode(int number, bool controller);
 
-std::tuple<double, double> GetPrimeStickXY();
-std::tuple<bool, bool> GetBVMenuOptions();
+bool PrimeUseGyro(int number);
 
-std::tuple<double, double, bool, bool, bool, bool, bool> PrimeSettings();
+bool CheckPitchRecentre(int number);
+
+std::tuple<double, double> GetPrimeStickXY(int number);
+std::tuple<double, double> GetPrimeGyroPitchYaw(int number);
+std::tuple<bool, bool> GetBVMenuOptions(int number);
+
+std::tuple<double, double, bool, bool, bool, bool, bool> PrimeSettings(int number);
 WiimoteSource GetSource(unsigned int index);
 }  // namespace Wiimote
 

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -74,16 +74,6 @@ static const u16 metroid_button_bitmasks[] = {
     Wiimote::BUTTON_A,     Wiimote::BUTTON_B,    Wiimote::BUTTON_ONE, Wiimote::BUTTON_TWO,
     Wiimote::BUTTON_MINUS, Wiimote::BUTTON_PLUS, Wiimote::PAD_DOWN};
 
-constexpr std::array<std::string_view, 7> named_buttons{
-    "A", "B", "1", "2", "-", "+", "Home",
-};
-
-constexpr std::array<std::string_view, 7> metroid_named_buttons{
-  "Shoot / Select", "Jump / Cancel", "Map", "Menu / Hint", "Visor Menu \nMenu -", "Beam Menu \nHypermode \nMenu +", "Missile",
-};
-
-static const char* const prime_beams[] = {"Beam 1", "Beam 2", "Beam 3", "Beam 4"};
-static const char* const prime_visors[] = {"Visor 1", "Visor 2", "Visor 3", "Visor 4"};
 
 void Wiimote::Reset()
 {
@@ -328,6 +318,9 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index), m_bt_device_index(i
   m_options->AddSetting(&m_sideways_setting,
                         {SIDEWAYS_OPTION, nullptr, nullptr, _trans("Sideways Wii Remote")}, false);
 
+  constexpr const char* const prime_beams[] = {_trans("Beam 1"), _trans("Beam 2"), _trans("Beam 3"), _trans("Beam 4")};
+  constexpr const char* const prime_visors[] = {_trans("Visor 1"), _trans("Visor 2"), _trans("Visor 3"), _trans("Visor 4")};
+
   // Adding PrimeHack Buttons
   groups.emplace_back(m_primehack_beams = new ControllerEmu::ControlGroup(_trans("PrimeHack"), ControllerEmu::GroupType::Beams));
   for (const char* prime_button : prime_beams)
@@ -389,12 +382,20 @@ Wiimote::Wiimote(const unsigned int index) : m_index(index), m_bt_device_index(i
       {"Cursor Sensitivity", nullptr, nullptr, _trans("Cursor Sensitivity")}, 15, 1, 100);
 
   constexpr auto gate_radius = ControlState(STICK_GATE_RADIUS) / STICK_RADIUS;
-  groups.emplace_back(m_primehack_stick =
-    new ControllerEmu::OctagonAnalogStick(_trans("Camera Control"), gate_radius));
+  groups.emplace_back(m_primehack_stick = new ControllerEmu::OctagonAnalogStick(
+                          "PrimeHack CameraStick", _trans("Camera Control"), gate_radius));
 
   m_primehack_stick->AddSetting(&m_primehack_horizontal_sensitivity, {"Horizontal Sensitivity", nullptr, nullptr, _trans("Horizontal Sensitivity")}, 45, 1, 100);
   m_primehack_stick->AddSetting(&m_primehack_vertical_sensitivity, {"Vertical Sensitivity", nullptr, nullptr, _trans("Vertical Sensitivity")}, 35, 1, 100);
+  m_primehack_stick->AddSetting(&m_primehack_gyro_enable, {"Enable Gyro", nullptr, nullptr, _trans("Enable Gyro")}, false);
   m_primehack_stick->AddInput(Translatability::Translate, _trans("Reset Camera Pitch"));
+
+  groups.emplace_back(m_primehack_gyro = new ControllerEmu::IMUGyroscope(
+                          "PrimeHack CameraGyro", _trans("Gyro Camera")));
+
+  m_primehack_gyro->AddSetting(&m_primehack_gyro_horizontal_sensitivity, {"Horizontal Sensitivity", nullptr, nullptr, _trans("Horizontal Sensitivity")}, 0.45, 0.1, 10.0);
+  m_primehack_gyro->AddSetting(&m_primehack_gyro_vertical_sensitivity, {"Vertical Sensitivity", nullptr, nullptr, _trans("Vertical Sensitivity")}, 0.3, 0.1, 10.0);
+  m_primehack_gyro->AddInput(ControllerEmu::Translatability::Translate, _trans("Activate"));
 
   groups.emplace_back(m_primehack_modes = new ControllerEmu::PrimeHackModes(_trans("PrimeHack")));
 
@@ -481,6 +482,8 @@ ControllerEmu::ControlGroup* Wiimote::GetWiimoteGroup(WiimoteGroup group) const
     return m_primehack_modes;
   case WiimoteGroup::AltProfileControls:
     return m_primehack_altprofile_controls;
+  case WiimoteGroup::GyroCamera:
+    return m_primehack_gyro;
   default:
     ASSERT(false);
     return nullptr;
@@ -1175,6 +1178,19 @@ void Wiimote::ChangeUIPrimeHack(bool useMetroidUI)
   // Swap D-Pad Down (Missile) and HOME
   std::swap(m_buttons->controls[6], m_dpad->controls[1]);
 
+  constexpr const char* named_buttons[] = {
+    A_BUTTON, B_BUTTON, ONE_BUTTON, TWO_BUTTON, MINUS_BUTTON, PLUS_BUTTON, HOME_BUTTON
+  };
+  constexpr const char* metroid_named_buttons[] = {
+    _trans("Shoot / Select"),
+    _trans("Jump / Cancel"),
+    _trans("Map"),
+    _trans("Menu / Hint"),
+    _trans("Visor Menu \nMenu -"),
+    _trans("Beam Menu \nHypermode \nMenu +"),
+    _trans("Missile")
+  };
+
   for (int i = 0; i < 7; i++)
   {
     std::string_view ui_name = useMetroidUI ? metroid_named_buttons[i] : named_buttons[i];
@@ -1182,13 +1198,13 @@ void Wiimote::ChangeUIPrimeHack(bool useMetroidUI)
     if (ui_name == "Home")
       ui_name = "HOME";
 
-    m_buttons->controls[i]->ui_name = _trans(ui_name);
+    m_buttons->controls[i]->ui_name = ui_name;
     m_buttons->controls[i]->display_alt = useMetroidUI;
   }
 
   if (!useMetroidUI) {
     // Make sure to revert the D-Pad name
-    m_dpad->controls[1]->ui_name = _trans(named_directions[1]);
+    m_dpad->controls[1]->ui_name = named_directions[1];
     m_dpad->controls[1]->display_alt = false;
   }
 
@@ -1254,6 +1270,16 @@ std::tuple<double, double> Wiimote::GetPrimeStickXY()
   return std::make_tuple(stick_state.x * m_primehack_horizontal_sensitivity.GetValue(), stick_state.y * -m_primehack_vertical_sensitivity.GetValue());
 }
 
+std::tuple<double, double> Wiimote::GetPrimeGyroPitchYaw()
+{
+  const auto gyro_state = m_primehack_gyro->GetState().value_or(ControllerEmu::IMUGyroscope::StateData{});
+  const auto gyro_hsens = m_primehack_gyro_horizontal_sensitivity.GetValue() * (360.0 / MathUtil::TAU);
+  const auto gyro_vsens = m_primehack_gyro_vertical_sensitivity.GetValue() * (360.0 / MathUtil::TAU);
+  const auto gyro_act = (double)(m_primehack_gyro->controls[6]->GetState() > 0.5);
+
+  return std::make_tuple(gyro_state.x * gyro_vsens * gyro_act, -gyro_state.z * gyro_hsens * gyro_act);
+}
+
 bool Wiimote::CheckPitchRecentre()
 {
   return m_primehack_stick->controls[5]->GetState() > 0.5;
@@ -1267,6 +1293,16 @@ std::tuple<bool, bool> Wiimote::GetBVMenuOptions()
 bool Wiimote::PrimeControllerMode()
 {
   return m_primehack_modes->GetSelectedDevice() == 1;
+}
+
+void Wiimote::SetPrimeMode(bool controller)
+{
+  m_primehack_modes->SetSelectedDevice(controller ? 1 : 0);
+}
+
+bool Wiimote::PrimeUseGyro()
+{
+  return m_primehack_gyro_enable.GetValue();
 }
 
 std::tuple<double, double, bool, bool, bool, bool, bool> Wiimote::GetPrimeSettings()

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.h
@@ -72,7 +72,8 @@ enum class WiimoteGroup
   Misc,
   ControlStick,
   Modes,
-  AltProfileControls
+  AltProfileControls,
+  GyroCamera
 };
 
 enum class NunchukGroup;
@@ -193,9 +194,12 @@ public:
   bool IsGrappleBinded();
   bool CheckImprovedMotions();
   bool PrimeControllerMode();
+  void SetPrimeMode(bool controller);
+  bool PrimeUseGyro();
   std::tuple<bool, bool> GetBVMenuOptions();
 
   std::tuple<double, double> GetPrimeStickXY();
+  std::tuple<double, double> GetPrimeGyroPitchYaw();
   bool CheckPitchRecentre();
 
   std::tuple <double, double, bool, bool, bool, bool, bool> GetPrimeSettings();
@@ -345,6 +349,7 @@ private:
   ControllerEmu::PrimeHackAltProfile* m_primehack_altprofile_controls;
   ControllerEmu::PrimeHackModes* m_primehack_modes;
   ControllerEmu::AnalogStick* m_primehack_stick;
+  ControllerEmu::IMUGyroscope* m_primehack_gyro;
 
   ControllerEmu::SettingValue<bool> m_sideways_setting;
   ControllerEmu::SettingValue<bool> m_upright_setting;
@@ -357,6 +362,8 @@ private:
   ControllerEmu::SettingValue<double> m_primehack_cursor_sensitivity;
   ControllerEmu::SettingValue<double> m_primehack_horizontal_sensitivity;
   ControllerEmu::SettingValue<double> m_primehack_vertical_sensitivity;
+  ControllerEmu::SettingValue<double> m_primehack_gyro_horizontal_sensitivity;
+  ControllerEmu::SettingValue<double> m_primehack_gyro_vertical_sensitivity;
 
   ControllerEmu::SettingValue<bool> m_primehack_invert_y;
   ControllerEmu::SettingValue<bool> m_primehack_invert_x;
@@ -369,6 +376,7 @@ private:
   ControllerEmu::SettingValue<bool> m_primehack_scalesens;
   ControllerEmu::SettingValue<bool> m_primehack_movereticle;
   ControllerEmu::SettingValue<bool> m_primehack_remap_map_controls;
+  ControllerEmu::SettingValue<bool> m_primehack_gyro_enable;
 
   static constexpr u8 STICK_GATE_RADIUS = 0x60;
   static constexpr u8 STICK_CENTER = 0x80;

--- a/Source/Core/Core/PrimeHack/HackConfig.cpp
+++ b/Source/Core/Core/PrimeHack/HackConfig.cpp
@@ -75,83 +75,83 @@ void EnableDefaultMods() {
 }
 
 bool CheckBeamCtl(int beam_num) {
-  return Wiimote::CheckBeam(beam_num);
+  return Wiimote::CheckBeam(0, beam_num);
 }
 
 bool CheckVisorCtl(int visor_num) {
-  return Wiimote::CheckVisor(visor_num);
+  return Wiimote::CheckVisor(0, visor_num);
 }
 
 bool CheckVisorScrollCtl(bool direction) {
-  return Wiimote::CheckVisorScroll(direction);
+  return Wiimote::CheckVisorScroll(0, direction);
 }
 
 bool CheckBeamScrollCtl(bool direction) {
-  return Wiimote::CheckBeamScroll(direction);
+  return Wiimote::CheckBeamScroll(0, direction);
 }
 
 bool CheckSpringBallCtl() {
   if (GetActiveGame() >= Game::PRIME_1_GCN) {
-    return Pad::CheckSpringBall();
+    return Pad::CheckSpringBall(0);
   } else {
-    return Wiimote::CheckSpringBall();
+    return Wiimote::CheckSpringBall(0);
   }
 }
 
 bool ImprovedMotionControls() {
-  return Wiimote::CheckImprovedMotions();
+  return Wiimote::CheckImprovedMotions(0);
 }
 
 bool CheckForward() {
   if (GetActiveGame() >= Game::PRIME_1_GCN) {
-    return Pad::CheckForward();
+    return Pad::CheckForward(0);
   } else {
-    return Wiimote::CheckForward();
+    return Wiimote::CheckForward(0);
   }
 }
 
 bool CheckBack() {
   if (GetActiveGame() >= Game::PRIME_1_GCN) {
-    return Pad::CheckBack();
+    return Pad::CheckBack(0);
   } else {
-    return Wiimote::CheckBack();
+    return Wiimote::CheckBack(0);
   }
 }
 
 bool CheckLeft() {
   if (GetActiveGame() >= Game::PRIME_1_GCN) {
-    return Pad::CheckLeft();
+    return Pad::CheckLeft(0);
   } else {
-    return Wiimote::CheckLeft();
+    return Wiimote::CheckLeft(0);
   }
 }
 
 bool CheckRight() {
   if (GetActiveGame() >= Game::PRIME_1_GCN) {
-    return Pad::CheckRight();
+    return Pad::CheckRight(0);
   } else {
-    return Wiimote::CheckRight();
+    return Wiimote::CheckRight(0);
   }
 }
 
 bool CheckJump() {
   if (GetActiveGame() >= Game::PRIME_1_GCN) {
-    return Pad::CheckJump();
+    return Pad::CheckJump(0);
   } else {
-    return Wiimote::CheckJump();
+    return Wiimote::CheckJump(0);
   }
 }
 
 bool CheckGrappleCtl() {
-  return Wiimote::CheckGrapple();
+  return Wiimote::CheckGrapple(0);
 }
 
 bool GrappleTappingMode() {
-  return Wiimote::UseGrappleTapping();
+  return Wiimote::UseGrappleTapping(0);
 }
 
 bool GrappleCtlBound() {
-  return Wiimote::GrappleCtlBound();
+  return Wiimote::GrappleCtlBound(0);
 }
 
 void SetEFBToTexture(bool toggle) {
@@ -260,10 +260,10 @@ void UpdateHackSettings() {
 
   if (GetActiveGame() >= Game::PRIME_1_GCN) {
     std::tie<double, double, bool, bool, bool>(camera, cursor, invertx, inverty, new_controls) =
-      Pad::PrimeSettings();
+      Pad::PrimeSettings(0);
   } else {
     std::tie<double, double, bool, bool, bool, bool>(camera, cursor, invertx, inverty, scale_sens, lock, new_controls) =
-      Wiimote::PrimeSettings();
+      Wiimote::PrimeSettings(0);
   }
 
   SetSensitivity((float)camera);
@@ -351,9 +351,9 @@ void SetScaleCursorSensitivity(bool scale) {
 bool CheckPitchRecentre() {
   if (ControllerMode()) {
     if (GetActiveGame() >= Game::PRIME_1_GCN) {
-      return Pad::CheckPitchRecentre();
+      return Pad::CheckPitchRecentre(0);
     } else {
-      return Wiimote::CheckPitchRecentre();
+      return Wiimote::CheckPitchRecentre(0);
     }
   }
 
@@ -366,19 +366,21 @@ bool ControllerMode() {
   }
 
   if (GetActiveGame() >= Game::PRIME_1_GCN) {
-    return Pad::PrimeUseController();
+    return Pad::PrimeUseController(0);
   } else {
-    return Wiimote::PrimeUseController();
+    return Wiimote::PrimeUseController(0);
   }
 }
 
 double GetHorizontalAxis() {
   if (GetActiveGame() >= Game::PRIME_1_GCN) {
-    if (Pad::PrimeUseController()) {
-      return std::get<0>(Pad::GetPrimeStickXY());
+    if (Pad::PrimeUseController(0)) {
+      return std::get<0>(Pad::GetPrimeStickXY(0))
+             + (Pad::PrimeUseGyro(0) ? std::get<1>(Pad::GetPrimeGyroPitchYaw(0)) : 0.0);
     }
-  } else if (Wiimote::PrimeUseController()) {
-    return std::get<0>(Wiimote::GetPrimeStickXY());
+  } else if (Wiimote::PrimeUseController(0)) {
+    return std::get<0>(Wiimote::GetPrimeStickXY(0))
+           + (Wiimote::PrimeUseGyro(0) ? std::get<1>(Wiimote::GetPrimeGyroPitchYaw(0)) : 0.0);
   }
 
   if (!Host_RendererHasFocus()) {
@@ -390,11 +392,13 @@ double GetHorizontalAxis() {
 
 double GetVerticalAxis() {
   if (GetActiveGame() >= Game::PRIME_1_GCN) {
-    if (Pad::PrimeUseController()) {
-      return std::get<1>(Pad::GetPrimeStickXY());
+    if (Pad::PrimeUseController(0)) {
+      return std::get<1>(Pad::GetPrimeStickXY(0))
+             + (Pad::PrimeUseGyro(0) ? std::get<0>(Pad::GetPrimeGyroPitchYaw(0)) : 0.0);
     }
-  } else if (Wiimote::PrimeUseController()) {
-    return std::get<1>(Wiimote::GetPrimeStickXY());
+  } else if (Wiimote::PrimeUseController(0)) {
+    return std::get<1>(Wiimote::GetPrimeStickXY(0))
+           + (Wiimote::PrimeUseGyro(0) ? std::get<0>(Wiimote::GetPrimeGyroPitchYaw(0)) : 0.0);
   }
 
   if (!Host_RendererHasFocus()) {
@@ -417,7 +421,7 @@ CameraLock GetLockCamera() {
 }
 
 std::tuple<bool, bool> GetMenuOptions() {
-  return Wiimote::GetBVMenuOptions();
+  return Wiimote::GetBVMenuOptions(0);
 }
 
 AddressDB* GetAddressDB() {

--- a/Source/Core/DolphinQt/Config/Mapping/GCPadEmuMetroid.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/GCPadEmuMetroid.cpp
@@ -110,11 +110,7 @@ void GCPadEmuMetroid::CreateMainLayout()
   // Column 3
 
   auto* groupbox3 = new QVBoxLayout();
-
-  auto* modes_group = Pad::GetGroup(GetPort(), PadGroup::Modes);
-  auto* modes = CreateGroupBox(tr("Mode"), modes_group);
-
-  auto* ce_modes = static_cast<ControllerEmu::PrimeHackModes*>(modes_group);
+  auto* modes = CreateGroupBox(tr("Mode"), Pad::GetGroup(GetPort(), PadGroup::Modes));
 
   const auto combo_hbox = new QHBoxLayout;
   combo_hbox->setAlignment(Qt::AlignCenter);
@@ -135,15 +131,22 @@ void GCPadEmuMetroid::CreateMainLayout()
       Pad::GetGroup(GetPort(), PadGroup::Camera));
   groupbox3->addWidget(camera_options, 0, Qt::AlignTop);
 
-  camera_control = CreateGroupBox(tr("Camera (Controller)"), Pad::GetGroup(
-    GetPort(), PadGroup::ControlStick));
-  camera_control->setEnabled(ce_modes->GetSelectedDevice() == 1);
+  camera_control = CreateGroupBox(tr("Camera Control"), Pad::GetGroup(GetPort(), PadGroup::ControlStick));
+  camera_control->setEnabled(Pad::PrimeUseController(GetPort()));
   groupbox3->addWidget(camera_control, 1);
+
+  // Column 4
+  auto* groupbox4 = new QVBoxLayout();
+  gyro_control = CreateGroupBox(tr("Gyro Camera"), Pad::GetGroup(GetPort(), PadGroup::GyroCamera));
+  gyro_control->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  gyro_control->setEnabled(Pad::PrimeUseController(GetPort()) && Pad::PrimeUseGyro(GetPort()));
+  groupbox4->addWidget(gyro_control);
 
   layout->addLayout(groupbox0);
   layout->addLayout(groupbox1);
   layout->addLayout(groupbox2);
   layout->addLayout(groupbox3);
+  layout->addLayout(groupbox4);
 
   setLayout(layout);
 }
@@ -160,11 +163,9 @@ void GCPadEmuMetroid::Connect()
 
 void GCPadEmuMetroid::OnDeviceSelected()
 {
-  auto* ce_modes = static_cast<ControllerEmu::PrimeHackModes*>(
-    Pad::GetGroup(GetPort(), PadGroup::Modes));
-
-  ce_modes->SetSelectedDevice(m_radio_mouse->isChecked() ? 0 : 1);
-  camera_control->setEnabled(!m_radio_mouse->isChecked());
+  Pad::PrimeSetMode(GetPort(), m_radio_controller->isChecked());
+  camera_control->setEnabled(m_radio_controller->isChecked());
+  gyro_control->setEnabled(m_radio_controller->isChecked() && Pad::PrimeUseGyro(GetPort()));
 
   ConfigChanged();
   SaveSettings();
@@ -177,13 +178,15 @@ void GCPadEmuMetroid::ConfigChanged()
 
 void GCPadEmuMetroid::Update()
 {
-  bool checked = Pad::PrimeUseController();
+  bool use_controller = Pad::PrimeUseController(GetPort());
 
-  camera_control->setEnabled(checked);
+  camera_control->setEnabled(use_controller);
+  gyro_control->setEnabled(use_controller && Pad::PrimeUseGyro(GetPort()));
 
-  if (m_radio_controller->isChecked() != checked) {
-    m_radio_controller->setChecked(checked);
-    m_radio_mouse->setChecked(!checked);
+  if (m_radio_controller->isChecked() != use_controller)
+  {
+    m_radio_controller->setChecked(use_controller);
+    m_radio_mouse->setChecked(!use_controller);
   }
 }
 
@@ -209,6 +212,7 @@ void GCPadEmuMetroid::LoadSettings()
   m_radio_mouse->setChecked(checked);
   m_radio_controller->setChecked(!checked);
   camera_control->setEnabled(!checked);
+  gyro_control->setEnabled(!checked && Pad::PrimeUseGyro(GetPort()));
 }
 
 void GCPadEmuMetroid::SaveSettings()

--- a/Source/Core/DolphinQt/Config/Mapping/GCPadEmuMetroid.h
+++ b/Source/Core/DolphinQt/Config/Mapping/GCPadEmuMetroid.h
@@ -19,6 +19,7 @@ public:
   InputConfig* GetConfig() override;
 
   QGroupBox* camera_control;
+  QGroupBox* gyro_control;
   QRadioButton* m_radio_mouse;
   QRadioButton* m_radio_controller;
   QPushButton* m_help_button;

--- a/Source/Core/DolphinQt/Config/Mapping/PrimeHackEmuGC.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/PrimeHackEmuGC.cpp
@@ -34,11 +34,9 @@ void PrimeHackEmuGC::CreateMainLayout()
 
   auto* groupbox1 = new QVBoxLayout();
   auto* groupbox2 = new QVBoxLayout();
+  auto* groupbox3 = new QVBoxLayout();
 
-  auto* modes_group = Pad::GetGroup(GetPort(), PadGroup::Modes);
-  auto* modes = CreateGroupBox(tr("Mode"), modes_group);
-
-  auto* ce_modes = static_cast<ControllerEmu::PrimeHackModes*>(modes_group);
+  auto* modes = CreateGroupBox(tr("Mode"), Pad::GetGroup(GetPort(), PadGroup::Modes));
 
   const auto combo_hbox = new QHBoxLayout;
   combo_hbox->setAlignment(Qt::AlignCenter);
@@ -79,11 +77,18 @@ void PrimeHackEmuGC::CreateMainLayout()
     GetPort(), PadGroup::ControlStick));
 
   controller_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-  controller_box->setEnabled(ce_modes->GetSelectedDevice() == 1);
+  controller_box->setEnabled(Pad::PrimeUseController(GetPort()));
 
   groupbox2->addWidget(controller_box, 2, Qt::AlignTop);
 
   layout->addLayout(groupbox2, 0, 1, Qt::AlignTop);
+
+  gyro_box = CreateGroupBox(tr("Gyro Camera"), Pad::GetGroup(GetPort(), PadGroup::GyroCamera));
+  gyro_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  gyro_box->setEnabled(Pad::PrimeUseController(GetPort()) && Pad::PrimeUseGyro(GetPort()));
+
+  groupbox3->addWidget(gyro_box);
+  layout->addLayout(groupbox3, 0, 2);
 
   setLayout(layout);
 }
@@ -100,11 +105,9 @@ void PrimeHackEmuGC::Connect(MappingWindow* window)
 
 void PrimeHackEmuGC::OnDeviceSelected()
 {
-  auto* ce_modes = static_cast<ControllerEmu::PrimeHackModes*>(
-    Pad::GetGroup(GetPort(), PadGroup::Modes));
-
-  ce_modes->SetSelectedDevice(m_radio_button->isChecked() ? 0 : 1);
-  controller_box->setEnabled(!m_radio_button->isChecked());
+  Pad::PrimeSetMode(GetPort(), m_radio_controller->isChecked());
+  controller_box->setEnabled(m_radio_controller->isChecked());
+  gyro_box->setEnabled(m_radio_controller->isChecked() && Pad::PrimeUseGyro(GetPort()));
 
   ConfigChanged();
   SaveSettings();
@@ -120,13 +123,15 @@ void PrimeHackEmuGC::ConfigChanged()
 
 void PrimeHackEmuGC::Update()
 {
-  bool checked = Pad::PrimeUseController();
+  bool use_controller = Pad::PrimeUseController(GetPort());
 
-  controller_box->setEnabled(checked);
+  controller_box->setEnabled(use_controller);
+  gyro_box->setEnabled(use_controller && Pad::PrimeUseGyro(GetPort()));
 
-  if (m_radio_controller->isChecked() != checked) {
-    m_radio_controller->setChecked(checked);
-    m_radio_button->setChecked(!checked);
+  if (m_radio_controller->isChecked() != use_controller)
+  {
+    m_radio_controller->setChecked(use_controller);
+    m_radio_button->setChecked(!use_controller);
   }
 }
 
@@ -152,6 +157,7 @@ void PrimeHackEmuGC::LoadSettings()
   m_radio_button->setChecked(checked);
   m_radio_controller->setChecked(!checked);
   controller_box->setEnabled(!checked);
+  gyro_box->setEnabled(!checked && Pad::PrimeUseGyro(GetPort()));
 }
 
 void PrimeHackEmuGC::SaveSettings()

--- a/Source/Core/DolphinQt/Config/Mapping/PrimeHackEmuGC.h
+++ b/Source/Core/DolphinQt/Config/Mapping/PrimeHackEmuGC.h
@@ -19,6 +19,7 @@ public:
   InputConfig* GetConfig() override;
 
   QGroupBox* controller_box;
+  QGroupBox* gyro_box;
   QRadioButton* m_radio_button;
   QRadioButton* m_radio_controller;
 

--- a/Source/Core/DolphinQt/Config/Mapping/PrimeHackEmuWii.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/PrimeHackEmuWii.cpp
@@ -41,11 +41,9 @@ void PrimeHackEmuWii::CreateMainLayout()
 
   auto* groupbox1 = new QVBoxLayout();
   auto* groupbox2 = new QVBoxLayout();
+  auto* groupbox3 = new QVBoxLayout();
 
-  auto* modes_group = Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Modes);
-  auto* modes = CreateGroupBox(tr("Mode"), modes_group);
-
-  auto* ce_modes = static_cast<ControllerEmu::PrimeHackModes*>(modes_group);
+  auto* modes = CreateGroupBox(tr("Mode"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Modes));
 
   const auto combo_hbox = new QHBoxLayout;
   combo_hbox->setAlignment(Qt::AlignCenter);
@@ -105,11 +103,18 @@ void PrimeHackEmuWii::CreateMainLayout()
     GetPort(), WiimoteEmu::WiimoteGroup::ControlStick));
 
   controller_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-  controller_box->setEnabled(ce_modes->GetSelectedDevice() == 1);
+  controller_box->setEnabled(Wiimote::PrimeUseController(GetPort()));
 
   groupbox2->addWidget(controller_box, 2, Qt::AlignTop);
 
   layout->addLayout(groupbox2, 0, 1, Qt::AlignTop);
+
+  gyro_box = CreateGroupBox(tr("Gyro Camera"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::GyroCamera));
+  gyro_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  gyro_box->setEnabled(Wiimote::PrimeUseController(GetPort()) && Wiimote::PrimeUseGyro(GetPort()));
+
+  groupbox3->addWidget(gyro_box);
+  layout->addLayout(groupbox3, 0, 2);
 
   setLayout(layout);
 }
@@ -226,11 +231,9 @@ void PrimeHackEmuWii::Connect(MappingWindow* window)
 
 void PrimeHackEmuWii::OnDeviceSelected()
 {
-  auto* ce_modes = static_cast<ControllerEmu::PrimeHackModes*>(
-    Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Modes));
-
-  ce_modes->SetSelectedDevice(m_radio_mouse->isChecked() ? 0 : 1);
-  controller_box->setEnabled(!m_radio_mouse->isChecked());
+  Wiimote::PrimeSetMode(GetPort(), m_radio_controller->isChecked());
+  controller_box->setEnabled(m_radio_controller->isChecked());
+  gyro_box->setEnabled(m_radio_controller->isChecked() && Wiimote::PrimeUseGyro(GetPort()));
 
   ConfigChanged();
   SaveSettings();
@@ -245,13 +248,15 @@ void PrimeHackEmuWii::ConfigChanged()
 
 void PrimeHackEmuWii::Update()
 {
-  bool checked = Wiimote::PrimeUseController();
+  bool use_controller = Wiimote::PrimeUseController(GetPort());
 
-  controller_box->setEnabled(checked);
+  controller_box->setEnabled(use_controller);
+  gyro_box->setEnabled(use_controller && Wiimote::PrimeUseGyro(GetPort()));
 
-  if (m_radio_controller->isChecked() != checked) {
-    m_radio_controller->setChecked(checked);
-    m_radio_mouse->setChecked(!checked);
+  if (m_radio_controller->isChecked() != use_controller)
+  {
+    m_radio_controller->setChecked(use_controller);
+    m_radio_mouse->setChecked(!use_controller);
   }
 }
 
@@ -277,6 +282,7 @@ void PrimeHackEmuWii::LoadSettings()
   m_radio_mouse->setChecked(checked);
   m_radio_controller->setChecked(!checked);
   controller_box->setEnabled(!checked);
+  gyro_box->setEnabled(!checked && Wiimote::PrimeUseGyro(GetPort()));
 }
 
 void PrimeHackEmuWii::SaveSettings()

--- a/Source/Core/DolphinQt/Config/Mapping/PrimeHackEmuWii.h
+++ b/Source/Core/DolphinQt/Config/Mapping/PrimeHackEmuWii.h
@@ -19,6 +19,7 @@ public:
   InputConfig* GetConfig() override;
 
   QGroupBox* controller_box;
+  QGroupBox* gyro_box;
   QRadioButton* m_radio_mouse;
   QRadioButton* m_radio_controller;
   QComboBox* m_morphball_combobox;

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.cpp
@@ -190,10 +190,7 @@ void WiimoteEmuMetroid::CreateMainLayout()
 
   auto* groupbox3 = new QVBoxLayout();
 
-  auto* modes_group = Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Modes);
-  auto* modes = CreateGroupBox(tr("Mode"), modes_group);
-
-  auto* ce_modes = static_cast<ControllerEmu::PrimeHackModes*>(modes_group);
+  auto* modes = CreateGroupBox(tr("Mode"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Modes));
 
   const auto combo_hbox = new QHBoxLayout;
   combo_hbox->setAlignment(Qt::AlignCenter);
@@ -216,13 +213,22 @@ void WiimoteEmuMetroid::CreateMainLayout()
 
   camera_control = CreateGroupBox(tr("Camera (Controller)"), Wiimote::GetWiimoteGroup(
     GetPort(), WiimoteEmu::WiimoteGroup::ControlStick));
-  camera_control->setEnabled(ce_modes->GetSelectedDevice() == 1);
+  camera_control->setEnabled(Wiimote::PrimeUseController(GetPort()));
   groupbox3->addWidget(camera_control, 1);
+
+  // Column 4
+  auto* groupbox4 = new QVBoxLayout();
+  gyro_control = CreateGroupBox(tr("Gyro Camera"), Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::GyroCamera));
+  gyro_control->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  gyro_control->setEnabled(Wiimote::PrimeUseController(GetPort()) &&
+                           Wiimote::PrimeUseGyro(GetPort()));
+  groupbox4->addWidget(gyro_control);
 
   layout->addLayout(groupbox0);
   layout->addLayout(groupbox1);
   layout->addLayout(groupbox2);
   layout->addLayout(groupbox3);
+  layout->addLayout(groupbox4);
 
   setLayout(layout);
 }
@@ -246,11 +252,9 @@ void WiimoteEmuMetroid::Connect()
 
 void WiimoteEmuMetroid::OnDeviceSelected()
 {
-  auto* ce_modes = static_cast<ControllerEmu::PrimeHackModes*>(
-    Wiimote::GetWiimoteGroup(GetPort(), WiimoteEmu::WiimoteGroup::Modes));
-
-  ce_modes->SetSelectedDevice(m_radio_mouse->isChecked() ? 0 : 1);
-  camera_control->setEnabled(!m_radio_mouse->isChecked());
+  Wiimote::PrimeSetMode(GetPort(), m_radio_controller->isChecked());
+  camera_control->setEnabled(m_radio_controller->isChecked());
+  gyro_control->setEnabled(m_radio_controller->isChecked() && Wiimote::PrimeUseGyro(GetPort()));
 
   ConfigChanged();
   SaveSettings();
@@ -302,13 +306,15 @@ void WiimoteEmuMetroid::ConfigChanged()
 
 void WiimoteEmuMetroid::Update()
 {
-  bool checked = Wiimote::PrimeUseController();
+  bool use_controller = Wiimote::PrimeUseController(GetPort());
 
-  camera_control->setEnabled(checked);
+  camera_control->setEnabled(use_controller);
+  gyro_control->setEnabled(use_controller && Wiimote::PrimeUseGyro(GetPort()));
 
-  if (m_radio_controller->isChecked() != checked) {
-    m_radio_controller->setChecked(checked);
-    m_radio_mouse->setChecked(!checked);
+  if (m_radio_controller->isChecked() != use_controller)
+  {
+    m_radio_controller->setChecked(use_controller);
+    m_radio_mouse->setChecked(!use_controller);
   }
 }
 
@@ -337,6 +343,7 @@ void WiimoteEmuMetroid::LoadSettings()
   m_radio_mouse->setChecked(checked);
   m_radio_controller->setChecked(!checked);
   camera_control->setEnabled(!checked);
+  gyro_control->setEnabled(!checked && Wiimote::PrimeUseGyro(GetPort()));
 
   QString text = tr(morph_group->GetAltProfileName().c_str());
 

--- a/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.h
+++ b/Source/Core/DolphinQt/Config/Mapping/WiimoteEmuMetroid.h
@@ -22,6 +22,7 @@ public:
   InputConfig* GetConfig() override;
 
   QGroupBox* camera_control;
+  QGroupBox* gyro_control;
   QRadioButton* m_radio_mouse;
   QRadioButton* m_radio_controller;
   QPushButton* m_help_button;


### PR DESCRIPTION
Using controller gyroscope capabilities for PrimeHack's camera (without an external program) is possible only through Dolphin's input expression system. This method however has the following drawbacks:
- The sensitivity values meant for the camera control stick are applied to gyro movements as well. A weighted sum would solve this but is an additional burden on the user (and makes fine-tuning annoying by having to edit four input slots).
- Stick output values are clamped to [-1,1] while gyro values are unbounded, meaning that users have to set their maximum comfortable rotation speed as a baseline for relative calculations. This is rather cumbersome and needlessly complicated.
- Stick output values are calibrated and reshaped by factoring in their euclidian norm. This
  - makes no sense mathematically for gyro values and
  - also reshapes the user's physical motions with potential movement artifacts, depending on the calibration shape.
- Only a single deadzone setting would be set for both stick and gyro movements, despite their differing ranges for ignoring inputs.

This feature branch proposes to add a new input group, which can be used in conjunction with the camera stick while in "Controller Mode", and is configurable from each of the PrimeHack-controller settings windows. This group makes use of Dolphin's pre-existing `IMUGyroscope` class, requiring no custom logic for dealing with this type of input. The group is extended with three additional properties:
- `Horizontal Sensitivity` setting - direct scaling factor for yaw rotations
- `Vertical Sensitivity` setting - direct scaling factor for pitch rotations
- `Activate` input slot - definable button that, while held, activates gyro camera control

The group can also be disabled or enabled in its entirety through a new setting in the camera stick's control group.

Note:
For better clarification, the PrimeHack camera stick control group has been internally renamed from `Camera Control` to `PrimeHack CameraStick`, as it is now paired with `PrimeHack CameraGyro`. Switching from the current PrimeHack version, users would have to reconfigure their stick settings or update the existing INI file to import previous stick settings.

Further Note:
While the set of changed files for this feature is kept minimal, most files that are affected where also touched upon with minor fixes and refactors disjointed from the feature (e.g. use of the i18n `_trans` macro for a variable). In particular, almost every PrimeHack interface in `GCPad.h` and `Wiimote.h` now takes in the controller port number as a parameter, so as to be more consistent with the remaining baseline Dolphin code. The UI code has also become observably more concise because of this. Should these disjointed changes impede the decision to merge this branch, a new branch with only feature-related changes can be made. 