### PR TITLE
Feature/mp3 mouse map control

### DIFF
--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -150,6 +150,12 @@ bool CheckJump() {
   return gcpad->groups[0]->controls[1]->control_ref->State() > 0.5;
 }
 
+bool CheckLockOn() {
+  GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(0));
+
+  return gcpad->groups[3]->controls[0]->control_ref->State() > 0.5;
+}
+
 std::tuple<double, double, bool, bool, bool> PrimeSettings()
 {
   GCPad* gcpad = static_cast<GCPad*>(s_config.GetController(0));

--- a/Source/Core/Core/HW/GCPad.h
+++ b/Source/Core/Core/HW/GCPad.h
@@ -45,6 +45,7 @@ bool CheckBack();
 bool CheckLeft();
 bool CheckRight();
 bool CheckJump();
+bool CheckLockOn();
 
 std::tuple<double, double> GetPrimeStickXY();
 

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -287,6 +287,13 @@ bool CheckJump() {
   return wiimote->groups[0].get()->controls[1]->control_ref->State() > 0.5;
 }
 
+bool CheckLockOn() {
+  WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
+
+  return wiimote->GetNunchukGroup(WiimoteEmu::NunchukGroup::Buttons)->
+      controls[1].get()->control_ref->State() > 0.5;
+}
+
 bool CheckGrapple() {
   WiimoteEmu::Wiimote* wiimote = static_cast<WiimoteEmu::Wiimote*>(s_config.GetController(0));
 

--- a/Source/Core/Core/HW/Wiimote.h
+++ b/Source/Core/Core/HW/Wiimote.h
@@ -112,6 +112,7 @@ bool CheckBack();
 bool CheckLeft();
 bool CheckRight();
 bool CheckJump();
+bool CheckLockOn();
 
 bool CheckGrapple();
 bool UseGrappleTapping();

--- a/Source/Core/Core/PrimeHack/AddressDBInit.cpp
+++ b/Source/Core/Core/PrimeHack/AddressDBInit.cpp
@@ -241,6 +241,7 @@ void init_db(AddressDB& addr_db) {
   addr_db.register_address(Game::PRIME_3, "world_id_base", 0x8066fcfc, 0x8067357c);
   addr_db.register_address(Game::PRIME_3, "rso_list_base", 0x805c9a5c, 0x805ccec4);
   addr_db.register_address(Game::PRIME_3, "xf_offset", 0x3c, 0x3c);
+  addr_db.register_address(Game::PRIME_3, "web_interface_list", 0x805c8d74, 0x805cc1d4); // first entry of this list is an index pointing to the list entry currently used. If zero then no CWebInterface is currently used. The list is used to organize stacked UI Elements.
 
   addr_db.register_dynamic_address(Game::PRIME_3, "object_list", "state_manager", {rp0, mrp1(0x1010), rp0});
   addr_db.register_dynamic_address(Game::PRIME_3, "area_id", "state_manager", {rp0, mrp1(0x2150)});
@@ -294,6 +295,7 @@ void init_db(AddressDB& addr_db) {
   addr_db.register_address(Game::PRIME_3_STANDALONE, "world_id_base", 0x8067dc0c, 0x80680234);
   addr_db.register_address(Game::PRIME_3_STANDALONE, "rso_list_base", 0x805c7dac, 0x805ca3c4);
   addr_db.register_address(Game::PRIME_3_STANDALONE, "xf_offset", 0x3c, 0x3c);
+  addr_db.register_address(Game::PRIME_3_STANDALONE, "web_interface_list", 0x805c70c4, 0x805c96dc); // first entry of this list is an index pointing to the list entry currently used. If zero then no CWebInterface is currently used. The list is used to organize stacked UI Elements.
 
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "object_list", "state_manager", {rp0, mrp1(0x1010), rp0});
   addr_db.register_dynamic_address(Game::PRIME_3_STANDALONE, "area_id", "state_manager", {rp0, mrp1(0x2150)});

--- a/Source/Core/Core/PrimeHack/HackConfig.cpp
+++ b/Source/Core/Core/PrimeHack/HackConfig.cpp
@@ -142,6 +142,14 @@ bool CheckJump() {
   }
 }
 
+bool CheckLockOn() {
+  if (GetActiveGame() >= Game::PRIME_1_GCN) {
+    return Pad::CheckLockOn();
+  } else {
+    return Wiimote::CheckLockOn();
+  }
+}
+
 bool CheckGrappleCtl() {
   return Wiimote::CheckGrapple();
 }

--- a/Source/Core/Core/PrimeHack/HackConfig.h
+++ b/Source/Core/Core/PrimeHack/HackConfig.h
@@ -25,6 +25,7 @@ bool CheckBack();
 bool CheckLeft();
 bool CheckRight();
 bool CheckJump();
+bool CheckLockOn();
 
 bool CheckGrappleCtl();
 bool GrappleTappingMode();

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
@@ -5,7 +5,10 @@
 #include "Core/PrimeHack/GuestAllocator.h"
 #include "Core/PrimeHack/Mods/StrafeControlPatches.h"
 #include "Core/PrimeHack/PrimeUtils.h"
+#include "Core/PrimeHack/HackConfig.h"
+#include "Core/PrimeHack/Mods/ModHeaders.h"
 #include "Core/System.h"
+#include "Core/HW/Wiimote.h"
 
 #include <cmath>
 
@@ -635,14 +638,22 @@ void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
 
   swap_alt_profiles(read32(ball_state), read32(menu_state), read32(screw_state));
 
-  if (read32(menu_state) == 1) {
-    write32(0x3f800000, cursor + 0x9c);
-    write32(0x3f800000, cursor + 0x15c);
-    return;
-  }
-  // Handles menu screen cursor
-  LOOKUP(cursor_dlg_enabled);
-  if (read8(cursor_dlg_enabled)) {
+  // handles menu screen cursor
+  LOOKUP(web_interface_list);
+  const u32 ui_depth = read32(web_interface_list);
+  const u32 web_interface = read32(web_interface_list + ui_depth * sizeof(u32));
+  if (web_interface != 0) {
+    const u32 web_interface_current_page_id = read32(web_interface + 0xa4);
+    const u32 map_page_id = 0x4c;
+    if (web_interface_current_page_id == map_page_id && prime::NewMapControlsEnabled() && !prime::CheckLockOn()) {
+      prime::EnableMod<MapController>();
+      write32(0x3f4ccccd, cursor + 0x9c);   // x: Button 9 [planet]
+      write32(0x00000000, cursor + 0x15c);  // y: Button 9 [planet]
+      return;
+    }
+    if (prime::NewMapControlsEnabled()) {
+      prime::DisableMod<MapController>();
+    }
     mp3_handle_cursor(false, false);
     return;
   }

--- a/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/FpsControls.cpp
@@ -635,6 +635,11 @@ void FpsControls::run_mod_mp3(Game active_game, Region active_region) {
 
   swap_alt_profiles(read32(ball_state), read32(menu_state), read32(screw_state));
 
+  if (read32(menu_state) == 1) {
+    write32(0x3f800000, cursor + 0x9c);
+    write32(0x3f800000, cursor + 0x15c);
+    return;
+  }
   // Handles menu screen cursor
   LOOKUP(cursor_dlg_enabled);
   if (read8(cursor_dlg_enabled)) {

--- a/Source/Core/Core/PrimeHack/Mods/MapController.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/MapController.cpp
@@ -79,14 +79,13 @@ void rotate_map_mp2(PowerPC::PowerPCState& ppc_state, PowerPC::MMU& mmu, u32 job
 
 void rotate_map_mp3(PowerPC::PowerPCState& ppc_state, PowerPC::MMU& mmu, u32 job)
 {
-  MapController* const map_controller =
-      static_cast<MapController*>(GetHackManager()->get_mod("map_controller"));
+  MapController* const map_controller = GetMod<MapController>();
   if (job == 0) {
-    if (ppc_state.gpr[30] == 1 && mmu.Read_U32(ppc_state.gpr[29] + 0x1d4) == 0) {
-      map_controller->reset_rotation(map_controller->get_player_yaw(),
-                                     mmu.Read_F32(ppc_state.gpr[29] + 0xdc) * -(kPi / 180.f));
+    if (ppc_state.gpr[30] == 1 && mmu.Read<u32>(ppc_state.gpr[29] + 0x1d4) == 0)
+    {
+      map_controller->reset_rotation(map_controller->get_player_yaw(), mmu.Read_F32(ppc_state.gpr[29] + 0xdc) * -(kPi / 180.f));
     }
-    ppc_state.gpr[24] = mmu.Read_U32(ppc_state.gpr[29] + 0x1d8);
+    ppc_state.gpr[24] = mmu.Read<u32>(ppc_state.gpr[29] + 0x1d8);
   } else if (job == 1) {
     quat r = map_controller->compute_orientation();
     write_quat(mmu, r, ppc_state.gpr[29] + 0xbc);
@@ -95,16 +94,14 @@ void rotate_map_mp3(PowerPC::PowerPCState& ppc_state, PowerPC::MMU& mmu, u32 job
 
 void rotate_map_mp3_sa(PowerPC::PowerPCState& ppc_state, PowerPC::MMU& mmu, u32 job)
 {
-  MapController* const map_controller =
-      static_cast<MapController*>(GetHackManager()->get_mod("map_controller"));
+  MapController* const map_controller = GetMod<MapController>();
   if (job == 0)
   {
-    if (ppc_state.gpr[31] == 1 && mmu.Read_U32(ppc_state.gpr[29] + 0x1f8) == 0)
+    if (ppc_state.gpr[31] == 1 && mmu.Read<u32>(ppc_state.gpr[29] + 0x1f8) == 0)
     {
-      map_controller->reset_rotation(map_controller->get_player_yaw(),
-                                     mmu.Read_F32(ppc_state.gpr[29] + 0x100) * -(kPi / 180.f));
+      map_controller->reset_rotation(map_controller->get_player_yaw(), mmu.Read_F32(ppc_state.gpr[29] + 0x100) * -(kPi / 180.f));
     }
-    ppc_state.gpr[24] = mmu.Read_U32(ppc_state.gpr[29] + 0x1fc);
+    ppc_state.gpr[24] = mmu.Read<u32>(ppc_state.gpr[29] + 0x1fc);
   }
   else if (job == 1)
   {  // Hooks ProcessMapRotateInput
@@ -113,9 +110,7 @@ void rotate_map_mp3_sa(PowerPC::PowerPCState& ppc_state, PowerPC::MMU& mmu, u32 
   }
 }
 
-
-
-}
+} // namespace
 
 float MapController::get_player_yaw() const {
   // HACK: This is called by a vmcall, so the thread guard will be invalid

--- a/Source/Core/Core/PrimeHack/Mods/MapController.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/MapController.cpp
@@ -77,43 +77,19 @@ void rotate_map_mp2(PowerPC::PowerPCState& ppc_state, PowerPC::MMU& mmu, u32 job
   }
 }
 
-// Quaternion Addresses and write calls
-// 80DD50FC -> 8001e364 stfs f0, 0x00BC (r31)
-// 80DD5100 -> 8001e380 stw r4, 0x00C0 (r31)
-// 80DD5104 -> 8001e378 stw r3, 0x00C4 (r31)
-// 80DD5108 -> 8001e388 stw r4, 0x00C8 (r31)
 void rotate_map_mp3(PowerPC::PowerPCState& ppc_state, PowerPC::MMU& mmu, u32 job)
 {
   MapController* const map_controller =
       static_cast<MapController*>(GetHackManager()->get_mod("map_controller"));
-
-  if (job == 8)
-  {
-    const u32 ret = LR(ppc_state);
-    INFO_LOG_FMT(VIDEO, "[MP3 Map] PAN OUTER caller RET = {:08x}", ret);
-
-    const u32 base = ret - 0x80;
-    for (u32 a = base; a <= ret + 0x20; a += 4)
-      INFO_LOG_FMT(VIDEO, "[MP3 Map] {:08x}: {:08x}", a, mmu.Read_U32(a));
-
-    // Replay original instruction at 0x8001E6B4: 0x806ddadc
-    // This is lwz r3, imm(r13) (uses SDA base in r13)
-    const s16 imm = static_cast<s16>(0xDADC);
-    ppc_state.gpr[3] = mmu.Read_U32(ppc_state.gpr[13] + static_cast<s32>(imm));
-    return;
-  }
-
-
-
-
-
-
-
-
-  if (job == 1)
-  {
+  if (job == 0) {
+    if (ppc_state.gpr[30] == 1 && mmu.Read_U32(ppc_state.gpr[29] + 0x1d4) == 0) {
+      map_controller->reset_rotation(map_controller->get_player_yaw(),
+                                     mmu.Read_F32(ppc_state.gpr[29] + 0xdc) * -(kPi / 180.f));
+    }
+    ppc_state.gpr[24] = mmu.Read_U32(ppc_state.gpr[29] + 0x1d8);
+  } else if (job == 1) {
     quat r = map_controller->compute_orientation();
-    write_quat(mmu, r, ppc_state.gpr[31] + 0xBC);
+    write_quat(mmu, r, ppc_state.gpr[29] + 0xbc);
   }
 }
 
@@ -339,25 +315,11 @@ void MapController::init_mod_mp3(Region region)
   }
   const u32 vmc_update_rotation = gen_vmcall(static_cast<u32>(map_controller_rotate), 0);
   const u32 vmc_rotate_map = gen_vmcall(static_cast<u32>(map_controller_rotate), 1);
-  const u32 vmc_pan_outer = gen_vmcall(static_cast<u32>(map_controller_rotate), 8);
-
-
-  if (region == Region::NTSC_U)
-  {
-    add_code_change(0x8002eadc, vmc_update_rotation);
-    add_code_change(0x800293d0, vmc_rotate_map);
-  }
-  else if (region == Region::PAL)
-  {
-    add_code_change(0x8001E6B4, vmc_pan_outer);
-    add_code_change(0x8001DFC4, 0x60000000);  // NEW: makes the whole rotate path run without direction
-    //add_code_change(0x8001E7F0, 0x60000000);      // allow pan without Z (PAL)
-    //add_code_change(0x8001E2EC, 0x60000000);      // your internal gate NOP (harmless to keep)
-    add_code_change(0x8001E364, vmc_rotate_map);  // your quat override
-
-    add_code_change(0x8001E378, 0x60000000);
-    add_code_change(0x8001E380, 0x60000000);
-    add_code_change(0x8001E388, 0x60000000);
+  if (region == Region::NTSC_U || region == Region::PAL) {
+    add_code_change(0x80021eb8, vmc_update_rotation);
+    add_code_change(0x8001D468, vmc_rotate_map);
+    add_code_change(0x8001E67C, 0x60000000);  // disable 'Z' gate
+    add_code_change(0x8001D430, 0x60000000);  // enable simultaneous panning and rotation
   }
 }
 

--- a/Source/Core/Core/PrimeHack/Mods/MapController.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/MapController.cpp
@@ -77,7 +77,69 @@ void rotate_map_mp2(PowerPC::PowerPCState& ppc_state, PowerPC::MMU& mmu, u32 job
   }
 }
 
-} // namespace
+// Quaternion Addresses and write calls
+// 80DD50FC -> 8001e364 stfs f0, 0x00BC (r31)
+// 80DD5100 -> 8001e380 stw r4, 0x00C0 (r31)
+// 80DD5104 -> 8001e378 stw r3, 0x00C4 (r31)
+// 80DD5108 -> 8001e388 stw r4, 0x00C8 (r31)
+void rotate_map_mp3(PowerPC::PowerPCState& ppc_state, PowerPC::MMU& mmu, u32 job)
+{
+  MapController* const map_controller =
+      static_cast<MapController*>(GetHackManager()->get_mod("map_controller"));
+
+  if (job == 8)
+  {
+    const u32 ret = LR(ppc_state);
+    INFO_LOG_FMT(VIDEO, "[MP3 Map] PAN OUTER caller RET = {:08x}", ret);
+
+    const u32 base = ret - 0x80;
+    for (u32 a = base; a <= ret + 0x20; a += 4)
+      INFO_LOG_FMT(VIDEO, "[MP3 Map] {:08x}: {:08x}", a, mmu.Read_U32(a));
+
+    // Replay original instruction at 0x8001E6B4: 0x806ddadc
+    // This is lwz r3, imm(r13) (uses SDA base in r13)
+    const s16 imm = static_cast<s16>(0xDADC);
+    ppc_state.gpr[3] = mmu.Read_U32(ppc_state.gpr[13] + static_cast<s32>(imm));
+    return;
+  }
+
+
+
+
+
+
+
+
+  if (job == 1)
+  {
+    quat r = map_controller->compute_orientation();
+    write_quat(mmu, r, ppc_state.gpr[31] + 0xBC);
+  }
+}
+
+void rotate_map_mp3_sa(PowerPC::PowerPCState& ppc_state, PowerPC::MMU& mmu, u32 job)
+{
+  MapController* const map_controller =
+      static_cast<MapController*>(GetHackManager()->get_mod("map_controller"));
+  if (job == 0)
+  {
+    if (ppc_state.gpr[31] == 1 && mmu.Read_U32(ppc_state.gpr[29] + 0x1f8) == 0)
+    {
+      map_controller->reset_rotation(map_controller->get_player_yaw(),
+                                     mmu.Read_F32(ppc_state.gpr[29] + 0x100) * -(kPi / 180.f));
+    }
+    ppc_state.gpr[24] = mmu.Read_U32(ppc_state.gpr[29] + 0x1fc);
+  }
+  else if (job == 1)
+  {  // Hooks ProcessMapRotateInput
+    quat r = map_controller->compute_orientation();
+    write_quat(mmu, r, ppc_state.gpr[29] + 0xec);
+  }
+}
+
+
+
+}
 
 float MapController::get_player_yaw() const {
   // HACK: This is called by a vmcall, so the thread guard will be invalid
@@ -134,22 +196,28 @@ quat MapController::compute_orientation() {
 
 bool MapController::init_mod(Game game, Region region) {
   switch (game) {
-    case Game::PRIME_1:
-      init_mod_mp1(region);
-      break;
-    case Game::PRIME_1_GCN:
-    case Game::PRIME_1_GCN_R1:
-    case Game::PRIME_1_GCN_R2:
-      init_mod_mp1_gc(game, region);
-      break;
-    case Game::PRIME_2:
-      init_mod_mp2(region);
-      break;
-    case Game::PRIME_2_GCN:
-      init_mod_mp2_gc(region);
-      break;
-    default:
-      break;
+  case Game::PRIME_1:
+    init_mod_mp1(region);
+    break;
+  case Game::PRIME_1_GCN:
+  case Game::PRIME_1_GCN_R1:
+  case Game::PRIME_1_GCN_R2:
+    init_mod_mp1_gc(game, region);
+    break;
+  case Game::PRIME_2:
+    init_mod_mp2(region);
+    break;
+  case Game::PRIME_2_GCN:
+    init_mod_mp2_gc(region);
+    break;
+  case Game::PRIME_3:
+    init_mod_mp3(region);
+    break;
+  case Game::PRIME_3_STANDALONE:
+    init_mod_mp3_sa(region);
+    break;
+  default:
+    break;
   }
   return true;
 }
@@ -252,6 +320,68 @@ void MapController::init_mod_mp2(Region region) {
     add_code_change(0x80029d88, 0x38a0002d);
     add_code_change(0x80029da8, 0x38a0002e);
   } else if (region == Region::PAL) {
+    add_code_change(0x80030030, vmc_update_rotation);
+    add_code_change(0x80029440, vmc_rotate_map);
+    add_code_change(0x80029db8, 0x38a0002b);
+    add_code_change(0x80029dd8, 0x38a0002c);
+    add_code_change(0x80029df8, 0x38a0002d);
+    add_code_change(0x80029e18, 0x38a0002e);
+  }
+}
+
+void MapController::init_mod_mp3(Region region)
+{
+  const int map_controller_rotate =
+      Core::System::GetInstance().GetPowerPC().RegisterVmcall(rotate_map_mp3);
+  if (map_controller_rotate == -1)
+  {
+    return;
+  }
+  const u32 vmc_update_rotation = gen_vmcall(static_cast<u32>(map_controller_rotate), 0);
+  const u32 vmc_rotate_map = gen_vmcall(static_cast<u32>(map_controller_rotate), 1);
+  const u32 vmc_pan_outer = gen_vmcall(static_cast<u32>(map_controller_rotate), 8);
+
+
+  if (region == Region::NTSC_U)
+  {
+    add_code_change(0x8002eadc, vmc_update_rotation);
+    add_code_change(0x800293d0, vmc_rotate_map);
+  }
+  else if (region == Region::PAL)
+  {
+    add_code_change(0x8001E6B4, vmc_pan_outer);
+    add_code_change(0x8001DFC4, 0x60000000);  // NEW: makes the whole rotate path run without direction
+    //add_code_change(0x8001E7F0, 0x60000000);      // allow pan without Z (PAL)
+    //add_code_change(0x8001E2EC, 0x60000000);      // your internal gate NOP (harmless to keep)
+    add_code_change(0x8001E364, vmc_rotate_map);  // your quat override
+
+    add_code_change(0x8001E378, 0x60000000);
+    add_code_change(0x8001E380, 0x60000000);
+    add_code_change(0x8001E388, 0x60000000);
+  }
+}
+
+void MapController::init_mod_mp3_sa(Region region)
+{
+  const int map_controller_rotate =
+      Core::System::GetInstance().GetPowerPC().RegisterVmcall(rotate_map_mp3_sa);
+  if (map_controller_rotate == -1)
+  {
+    return;
+  }
+  const u32 vmc_update_rotation = gen_vmcall(static_cast<u32>(map_controller_rotate), 0);
+  const u32 vmc_rotate_map = gen_vmcall(static_cast<u32>(map_controller_rotate), 1);
+  if (region == Region::NTSC_U)
+  {
+    add_code_change(0x8002eadc, vmc_update_rotation);
+    add_code_change(0x800293d0, vmc_rotate_map);
+    add_code_change(0x80029d48, 0x38a0002b);
+    add_code_change(0x80029d68, 0x38a0002c);
+    add_code_change(0x80029d88, 0x38a0002d);
+    add_code_change(0x80029da8, 0x38a0002e);
+  }
+  else if (region == Region::PAL)
+  {
     add_code_change(0x80030030, vmc_update_rotation);
     add_code_change(0x80029440, vmc_rotate_map);
     add_code_change(0x80029db8, 0x38a0002b);

--- a/Source/Core/Core/PrimeHack/Mods/MapController.cpp
+++ b/Source/Core/Core/PrimeHack/Mods/MapController.cpp
@@ -89,24 +89,45 @@ void rotate_map_mp3(PowerPC::PowerPCState& ppc_state, PowerPC::MMU& mmu, u32 job
   } else if (job == 1) {
     quat r = map_controller->compute_orientation();
     write_quat(mmu, r, ppc_state.gpr[29] + 0xbc);
-  }
-}
-
-void rotate_map_mp3_sa(PowerPC::PowerPCState& ppc_state, PowerPC::MMU& mmu, u32 job)
-{
-  MapController* const map_controller = GetMod<MapController>();
-  if (job == 0)
+  } else if (job == 2)  // This VMC is used to keep the map from jumping after certain page transitions.
   {
-    if (ppc_state.gpr[31] == 1 && mmu.Read<u32>(ppc_state.gpr[29] + 0x1f8) == 0)
+    // Original instruction: li r3, 1
+    ppc_state.gpr[3] = 1;
+
+    const u32 web_interface = ppc_state.gpr[26];
+    const u32 web_interface_main_index = mmu.Read<u32>( web_interface + 0x28c);  // This index is 0 when using the map and indexes which tab on the left side of the screen we are in.
+    const u32 web_interface_current_page_id = mmu.Read<u32>(web_interface + 0xa4);  // Currently displayed page id (e.g. 0x4c = map)
+    const u32 web_interface_target_page_id = mmu.Read<u32>(web_interface + 0xf8);  // Page id we are switching to
+    const u32 automapper = mmu.Read<u32>(web_interface + 0x1d4);
+    bool menu_startup = ppc_state.gpr[27] == 0;
+    const u32 map_page_id = 0x4c;   // 3D map id
+    const u32 room_page_id = 0x4f;  // Zoomed in 3D map id
+
+    if (menu_startup || web_interface_target_page_id != map_page_id || web_interface_current_page_id == map_page_id)
+      return;
+
+    if (web_interface_current_page_id == room_page_id)  // We go from a zoomed in 3D map (0x4F), back to a zoomed out 3D map (0x4C)
     {
-      map_controller->reset_rotation(map_controller->get_player_yaw(), mmu.Read_F32(ppc_state.gpr[29] + 0x100) * -(kPi / 180.f));
+      const float qx = mmu.Read_F32(automapper + 0xbc);
+      const float qy = mmu.Read_F32(automapper + 0xc0);
+      const float qz = mmu.Read_F32(automapper + 0xc4);
+      const float qw = mmu.Read_F32(automapper + 0xc8);
+
+      const float horizontal = atan2f(2.f * (qy * qz + qw * qx), 1.f - 2.f * (qx * qx + qy * qy));
+      const float vertical = atan2f(2.f * (qx * qy + qw * qz), 1.f - 2.f * (qy * qy + qz * qz));
+
+      map_controller->reset_rotation(horizontal, vertical); // Reset the rotation to the same values as the zoomed in 3D map, so that the transition is seamless.
     }
-    ppc_state.gpr[24] = mmu.Read<u32>(ppc_state.gpr[29] + 0x1fc);
-  }
-  else if (job == 1)
-  {  // Hooks ProcessMapRotateInput
-    quat r = map_controller->compute_orientation();
-    write_quat(mmu, r, ppc_state.gpr[29] + 0xec);
+    else if (web_interface_main_index == 0)  // We go from any 2D map (planet) to the 3D map.
+    {
+      // Quat values seem to always be the same when going from any planet to the 3D map.
+      // If an exception is found, this has to change.
+      map_controller->reset_rotation(kPi, -kPi / 4.f);
+    }
+    else  // We go from any non-map menu to the 3D map.
+    {
+      map_controller->reset_rotation(map_controller->get_player_yaw(), (mmu.Read_F32(automapper + 0xdc) - 30.f) * -(kPi / 180.f));  // No idea why the 30-degree offset is needed
+    }
   }
 }
 
@@ -167,30 +188,37 @@ quat MapController::compute_orientation() {
 
 bool MapController::init_mod(Game game, Region region) {
   switch (game) {
-  case Game::PRIME_1:
-    init_mod_mp1(region);
-    break;
-  case Game::PRIME_1_GCN:
-  case Game::PRIME_1_GCN_R1:
-  case Game::PRIME_1_GCN_R2:
-    init_mod_mp1_gc(game, region);
-    break;
-  case Game::PRIME_2:
-    init_mod_mp2(region);
-    break;
-  case Game::PRIME_2_GCN:
-    init_mod_mp2_gc(region);
-    break;
-  case Game::PRIME_3:
-    init_mod_mp3(region);
-    break;
-  case Game::PRIME_3_STANDALONE:
-    init_mod_mp3_sa(region);
-    break;
-  default:
-    break;
+    case Game::PRIME_1:
+      init_mod_mp1(region);
+      break;
+    case Game::PRIME_1_GCN:
+    case Game::PRIME_1_GCN_R1:
+    case Game::PRIME_1_GCN_R2:
+      init_mod_mp1_gc(game, region);
+      break;
+    case Game::PRIME_2:
+      init_mod_mp2(region);
+      break;
+    case Game::PRIME_2_GCN:
+      init_mod_mp2_gc(region);
+      break;
+    case Game::PRIME_3:
+      init_mod_mp3(region);
+      break;
+    case Game::PRIME_3_STANDALONE:
+      init_mod_mp3_sa(region);
+      break;
+    default:
+      break;
   }
   return true;
+}
+
+void MapController::on_state_change(ModState old_state) {
+  if (old_state == ModState::ENABLED) {
+    frame_dx = 0.f;
+    frame_dy = 0.f;
+  }
 }
 
 void MapController::init_mod_mp1_gc(Game game, Region region) {
@@ -302,17 +330,23 @@ void MapController::init_mod_mp2(Region region) {
 
 void MapController::init_mod_mp3(Region region)
 {
-  const int map_controller_rotate =
-      Core::System::GetInstance().GetPowerPC().RegisterVmcall(rotate_map_mp3);
-  if (map_controller_rotate == -1)
-  {
+  const int map_controller_rotate = Core::System::GetInstance().GetPowerPC().RegisterVmcall(rotate_map_mp3);
+  if (map_controller_rotate == -1) {
     return;
   }
   const u32 vmc_update_rotation = gen_vmcall(static_cast<u32>(map_controller_rotate), 0);
   const u32 vmc_rotate_map = gen_vmcall(static_cast<u32>(map_controller_rotate), 1);
-  if (region == Region::NTSC_U || region == Region::PAL) {
-    add_code_change(0x80021eb8, vmc_update_rotation);
+  const u32 vmc_menu_transition = gen_vmcall(static_cast<u32>(map_controller_rotate), 2);
+  if (region == Region::NTSC_U) {
+    add_code_change(0x80021EB8, vmc_update_rotation);
     add_code_change(0x8001D468, vmc_rotate_map);
+    add_code_change(0x802BC3D0, vmc_menu_transition);
+    add_code_change(0x8001E67C, 0x60000000);  // disable 'Z' gate
+    add_code_change(0x8001D430, 0x60000000);  // enable simultaneous panning and rotation
+  } else if (region == Region::PAL) {
+    add_code_change(0x80021EB8, vmc_update_rotation);
+    add_code_change(0x8001D468, vmc_rotate_map);
+    add_code_change(0x802BC0A8, vmc_menu_transition);
     add_code_change(0x8001E67C, 0x60000000);  // disable 'Z' gate
     add_code_change(0x8001D430, 0x60000000);  // enable simultaneous panning and rotation
   }
@@ -320,31 +354,25 @@ void MapController::init_mod_mp3(Region region)
 
 void MapController::init_mod_mp3_sa(Region region)
 {
-  const int map_controller_rotate =
-      Core::System::GetInstance().GetPowerPC().RegisterVmcall(rotate_map_mp3_sa);
-  if (map_controller_rotate == -1)
-  {
+  const int map_controller_rotate = Core::System::GetInstance().GetPowerPC().RegisterVmcall(rotate_map_mp3);
+  if (map_controller_rotate == -1) {
     return;
   }
   const u32 vmc_update_rotation = gen_vmcall(static_cast<u32>(map_controller_rotate), 0);
   const u32 vmc_rotate_map = gen_vmcall(static_cast<u32>(map_controller_rotate), 1);
-  if (region == Region::NTSC_U)
-  {
-    add_code_change(0x8002eadc, vmc_update_rotation);
-    add_code_change(0x800293d0, vmc_rotate_map);
-    add_code_change(0x80029d48, 0x38a0002b);
-    add_code_change(0x80029d68, 0x38a0002c);
-    add_code_change(0x80029d88, 0x38a0002d);
-    add_code_change(0x80029da8, 0x38a0002e);
-  }
-  else if (region == Region::PAL)
-  {
-    add_code_change(0x80030030, vmc_update_rotation);
-    add_code_change(0x80029440, vmc_rotate_map);
-    add_code_change(0x80029db8, 0x38a0002b);
-    add_code_change(0x80029dd8, 0x38a0002c);
-    add_code_change(0x80029df8, 0x38a0002d);
-    add_code_change(0x80029e18, 0x38a0002e);
+  const u32 vmc_menu_transition = gen_vmcall(static_cast<u32>(map_controller_rotate), 2);
+  if (region == Region::NTSC_U) {
+    add_code_change(0x80022114, vmc_update_rotation);
+    add_code_change(0x8001D6E8, vmc_rotate_map);
+    add_code_change(0x802BCD30, vmc_menu_transition);
+    add_code_change(0x8001E8FC, 0x60000000);  // disable 'Z' gate
+    add_code_change(0x8001D6B0, 0x60000000);  // enable simultaneous panning and rotation
+  } else if (region == Region::PAL) {
+    add_code_change(0x800221FC, vmc_update_rotation);
+    add_code_change(0x8001D7D0, vmc_rotate_map);
+    add_code_change(0x802BE1B4, vmc_menu_transition);
+    add_code_change(0x8001E9E4, 0x60000000);  // disable 'Z' gate
+    add_code_change(0x8001D798, 0x60000000);  // enable simultaneous panning and rotation
   }
 }
 

--- a/Source/Core/Core/PrimeHack/Mods/MapController.h
+++ b/Source/Core/Core/PrimeHack/Mods/MapController.h
@@ -23,6 +23,8 @@ private:
   void init_mod_mp1(Region region);
   void init_mod_mp2_gc(Region region);
   void init_mod_mp2(Region region);
+  void init_mod_mp3(Region region);
+  void init_mod_mp3_sa(Region region);
 
   float frame_dx, frame_dy;
   float x_rot, y_rot;

--- a/Source/Core/Core/PrimeHack/Mods/MapController.h
+++ b/Source/Core/Core/PrimeHack/Mods/MapController.h
@@ -10,7 +10,7 @@ class MapController : public PrimeMod {
 public:
   void run_mod(Game game, Region region) override;
   bool init_mod(Game game, Region region) override;
-  void on_state_change(ModState) override {}
+  void on_state_change(ModState) override;
   bool is_cheat() const override { return false; }
   GEN_NAME(MapController)
 


### PR DESCRIPTION
Hi, the past months I've been hard at work to create an implementation to control the map of Metroid Prime 3 with the mouse, as is done in the other games. Metroid Prime 3 is my favorite one of the trilogy (don't smite me), and I really yearned for this feature.
This was not as easy as I thought, but I made it work while still maintaining the usability of the menus.

Usage:
When the 3D map is open, you can rotate the map with mouse/R-stick and translate it with WASD/L-stick while the ingame cursor is locked to the [planet] button.
Hold the "Lock-On" button to control the cursor when using the 3D map.
The "Lock-On" button was chosen because it's the default way the game switches between rotation/translation in the 3D map.
Outside of the 3D map, the cursor functions as before.

I tried to keep the impact on the repo minimal and stay close to the syntax used by this project. I also tried to catch any situation where the map might "jump" after a transition, but I might have missed some.
Currently, the cursor is moveable when "Lock-On" is held. This feels natural for me, but maybe one prefers a switch instead. I am open to feedback.
Thank you.